### PR TITLE
feat(depandabot): Add a depandbot to the backend repositorie

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"         # Location of go.mod (use "/" for root)
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "albanemerian"
+      - "marinlamy"
+      - "Matisse-M"
+      - "noaroussiere"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"         # Location of go.mod (use "/" for root)
+    directory: "/app"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request introduces a new Dependabot configuration to automate dependency updates for Go modules. The configuration schedules weekly checks, assigns reviewers, and applies consistent labeling and commit message conventions for dependency update pull requests.

Dependency management automation:

* Added a `.github/dependabot.yml` file to enable Dependabot for Go modules (`gomod`), scheduling weekly updates, limiting open PRs to 10, and specifying reviewers and labels for improved workflow and visibility.