### PR TITLE
Adding refund license route

### DIFF
--- a/app/cmd/main.go
+++ b/app/cmd/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	licenseRepo := license.NewRepository(db, redisClient)
 	licenseService := license.NewService(licenseRepo)
+	licenseService.SetDependencies(storeService, profileService)
 	licenseHandler := license.NewHandler(licenseService)
 
 	accountRepo := account.NewRepository(db, redisClient)

--- a/app/internal/license/handler.go
+++ b/app/internal/license/handler.go
@@ -31,6 +31,7 @@ func (h *Handler) RegisterRoutes(router *gin.Engine) {
 	{
 		accountRoutes.GET("", h.GetLicences)
 		accountRoutes.POST("payment", h.CreatePaymentLink)
+		accountRoutes.POST("refund", h.RefundLicense)
 		accountRoutes.GET("/:id", h.GetByID)   // GET /licences/:id
 		accountRoutes.DELETE("/:id", h.Delete) // DELETE /licences/:id
 		accountRoutes.PUT("/:id", h.Update)    // PUT /licences/:id
@@ -91,6 +92,50 @@ func (h *Handler) CreatePaymentLink(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, PaymentLinkResponse{URL: url})
+}
+
+// RefundLicense refunds a licence and removes the dependent store and profiles.
+// @Summary      Refund a licence
+// @Description  Refunds the specified licence and deletes the associated store and profiles.
+// @Tags         licence
+// @Accept       json
+// @Produce      json
+// @Security     AccountToken
+// @Param        licenceId query     string true "Licence UUID"
+// @Success      204
+// @Failure      400  {object}  map[string]interface{}
+// @Failure      403  {object}  map[string]interface{}
+// @Failure      404  {object}  map[string]interface{}
+// @Failure      500  {object}  map[string]interface{}
+// @Router       /licences/refund [post]
+func (h *Handler) RefundLicense(c *gin.Context) {
+	accountID := c.GetInt("accountID")
+	licenceIDStr := c.Query("licenceId")
+	if licenceIDStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing licenceId query parameter"})
+		return
+	}
+
+	licenceID, err := uuid.Parse(licenceIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid licence ID"})
+		return
+	}
+
+	if err := h.service.Refund(c.Request.Context(), accountID, licenceID); err != nil {
+		if errors.Is(err, ErrLicenceNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "licence not found"})
+			return
+		}
+		if errors.Is(err, ErrForbidden) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "you are not the owner of this licence"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
 }
 
 // HandleStripeWebhook processes incoming Stripe webhook events, specifically handling completed checkout sessions to create licences.
@@ -167,6 +212,23 @@ func (h *Handler) HandleStripeWebhook(c *gin.Context) {
 		_, err = h.service.Create(c.Request.Context(), accountID, input)
 		if err != nil {
 			fmt.Printf("Erreur création licence: %v\n", err)
+		}
+	}
+
+	if event.Type == "customer.subscription.deleted" {
+		var sub stripe.Subscription
+		err := json.Unmarshal(event.Data.Raw, &sub)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Erreur parsing JSON"})
+			return
+		}
+		if sub.ID == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "subscription id manquant"})
+			return
+		}
+		if err := h.service.DeleteByStripeSubscriptionID(c.Request.Context(), sub.ID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
 	}
 	c.Status(http.StatusOK)

--- a/app/internal/license/handler_test.go
+++ b/app/internal/license/handler_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stripe/stripe-go/v84"
 	"github.com/stripe/stripe-go/v84/webhook"
-	"github.com/stretchr/testify/assert"
 
 	"tili/app/internal/profile"
 	"tili/app/internal/store"

--- a/app/internal/license/handler_test.go
+++ b/app/internal/license/handler_test.go
@@ -2,16 +2,22 @@ package license
 
 import (
 	"bytes"
+	"context"
 	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v84/webhook"
 	"github.com/stretchr/testify/assert"
 
+	"tili/app/internal/profile"
+	"tili/app/internal/store"
 	"tili/app/pkg/db"
 )
 
@@ -21,6 +27,7 @@ func setupLicenseHandler(t *testing.T) (*Handler, sqlmock.Sqlmock) {
 
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
+	svc.SetDependencies(store.NewService(store.NewRepository(&db.Db{DB: bunDB})), profile.NewService(profile.NewRepository(&db.Db{DB: bunDB})))
 	return NewHandler(svc), mock
 }
 
@@ -65,6 +72,93 @@ func TestLicenseHandler_HandleStripeWebhook_InvalidSignature(t *testing.T) {
 	r.POST("/api/webhooks/stripe", h.HandleStripeWebhook)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", bytes.NewBufferString("{}"))
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLicenseHandler_HandleStripeWebhook_CheckoutCompleted_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, mock := setupLicenseHandler(t)
+	r.POST("/api/webhooks/stripe", h.HandleStripeWebhook)
+
+	secret := "whsec_test"
+	t.Setenv("STRIPE_WEBHOOK_SECRET", secret)
+
+	payload := `{"id":"evt_test","object":"event","api_version":"2026-02-25.clover","type":"checkout.session.completed","data":{"object":{"id":"cs_test_create_1","object":"checkout.session","metadata":{"account_id":"1","offer":"mensuel"}}}}`
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload:   []byte(payload),
+		Secret:    secret,
+		Timestamp: time.Now(),
+		Scheme:    "v1",
+	})
+
+	mock.ExpectExec(`^INSERT INTO "licence"`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", bytes.NewBuffer(signed.Payload))
+	req.Header.Set("Stripe-Signature", signed.Header)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLicenseHandler_HandleStripeWebhook_SubscriptionDeleted_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, mock := setupLicenseHandler(t)
+	r.POST("/api/webhooks/stripe", h.HandleStripeWebhook)
+
+	secret := "whsec_test"
+	t.Setenv("STRIPE_WEBHOOK_SECRET", secret)
+
+	licID := uuid.New()
+	rows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "sub_123")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(transaction = .+\)$`).WillReturnRows(rows)
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	payload := `{"id":"evt_test","object":"event","api_version":"2026-02-25.clover","type":"customer.subscription.deleted","data":{"object":{"id":"sub_123","object":"subscription"}}}`
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload:   []byte(payload),
+		Secret:    secret,
+		Timestamp: time.Now(),
+		Scheme:    "v1",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", bytes.NewBuffer(signed.Payload))
+	req.Header.Set("Stripe-Signature", signed.Header)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLicenseHandler_HandleStripeWebhook_SubscriptionDeleted_MissingID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, _ := setupLicenseHandler(t)
+	r.POST("/api/webhooks/stripe", h.HandleStripeWebhook)
+
+	secret := "whsec_test"
+	t.Setenv("STRIPE_WEBHOOK_SECRET", secret)
+
+	payload := `{"id":"evt_test","object":"event","api_version":"2026-02-25.clover","type":"customer.subscription.deleted","data":{"object":{"object":"subscription"}}}`
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload:   []byte(payload),
+		Secret:    secret,
+		Timestamp: time.Now(),
+		Scheme:    "v1",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/webhooks/stripe", bytes.NewBuffer(signed.Payload))
+	req.Header.Set("Stripe-Signature", signed.Header)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -244,5 +338,84 @@ func TestLicenseHandler_Update_Forbidden(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLicenseHandler_RefundLicense_InvalidUUID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, _ := setupLicenseHandler(t)
+	r.Use(withLicenseAccountContext())
+	r.POST("/licences/refund-license", h.RefundLicense)
+
+	req := httptest.NewRequest(http.MethodPost, "/licences/refund-license?licenceId=bad-id", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestLicenseHandler_RefundLicense_NotFound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, mock := setupLicenseHandler(t)
+	r.Use(withLicenseAccountContext())
+	r.POST("/licences/refund-license", h.RefundLicense)
+
+	licID := uuid.New()
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/licences/refund-license?licenceId="+licID.String(), nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLicenseHandler_RefundLicense_Success(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	h, mock := setupLicenseHandler(t)
+	r.Use(withLicenseAccountContext())
+	r.POST("/licences/refund-license", h.RefundLicense)
+
+	origRetrieveCheckoutSession := retrieveCheckoutSession
+	origCancelSubscription := cancelSubscription
+	origCreateRefund := createRefund
+	t.Cleanup(func() {
+		retrieveCheckoutSession = origRetrieveCheckoutSession
+		cancelSubscription = origCancelSubscription
+		createRefund = origCreateRefund
+	})
+
+	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
+		return &stripe.CheckoutSession{Subscription: &stripe.Subscription{ID: "sub_123"}}, nil
+	}
+	cancelSubscription = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		return &stripe.Subscription{ID: subscriptionID}, nil
+	}
+	createRefund = func(ctx context.Context, paymentIntentID string) (*stripe.Refund, error) {
+		return &stripe.Refund{ID: "re_123"}, nil
+	}
+
+	licID := uuid.New()
+	storeID := 10
+	licRows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "cs_test_refund")
+	storeRows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation", "numero_tva", "siret"}).AddRow(storeID, "Refund Store", 1, licID, time.Now(), "", "")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnRows(licRows)
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(storeRows)
+	mock.ExpectExec(`^DELETE FROM "profile" AS "p" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "store" AS "s" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/licences/refund-license?licenceId="+licID.String(), nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/internal/license/repository.go
+++ b/app/internal/license/repository.go
@@ -68,6 +68,15 @@ func (r *Repository) FindByID(ctx context.Context, id uuid.UUID) (*Licence, erro
 	return l, nil
 }
 
+func (r *Repository) FindByTransaction(ctx context.Context, transaction string) (*Licence, error) {
+	l := &Licence{}
+	err := r.db.NewSelect().Model(l).Where("transaction = ?", transaction).Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
 func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 	_, err := r.db.NewDelete().Model(&Licence{}).Where("licence_id = ?", id).Exec(ctx)
 	_ = cache.DeletePrefix(ctx, r.cache, "license:")

--- a/app/internal/license/service.go
+++ b/app/internal/license/service.go
@@ -6,24 +6,78 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stripe/stripe-go/v84"
 	"github.com/stripe/stripe-go/v84/checkout/session"
+	refundapi "github.com/stripe/stripe-go/v84/refund"
+	subscriptionapi "github.com/stripe/stripe-go/v84/subscription"
+
+	"tili/app/internal/profile"
+	"tili/app/internal/store"
 )
 
 var (
 	ErrLicenceNotFound = errors.New("licence not found")
 	ErrForbidden       = errors.New("forbidden")
+
+	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
+		_ = ctx
+		return session.Get(sessionID, nil)
+	}
+
+	cancelSubscription = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		_ = ctx
+		return subscriptionapi.Cancel(subscriptionID, nil)
+	}
+
+	retrieveSubscriptionForRefund = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		_ = ctx
+		params := &stripe.SubscriptionParams{}
+		params.AddExpand("latest_invoice.payments")
+		// Stripe max expansion depth is 4 levels.
+		params.AddExpand("latest_invoice.payments.data.payment")
+		return subscriptionapi.Get(subscriptionID, params)
+	}
+
+	listCheckoutSessionsBySubscription = func(ctx context.Context, subscriptionID string) ([]*stripe.CheckoutSession, error) {
+		_ = ctx
+		params := &stripe.CheckoutSessionListParams{Subscription: stripe.String(subscriptionID)}
+		iter := session.List(params)
+		result := make([]*stripe.CheckoutSession, 0)
+		for iter.Next() {
+			result = append(result, iter.CheckoutSession())
+		}
+		if err := iter.Err(); err != nil {
+			return nil, err
+		}
+		return result, nil
+	}
+
+	createRefund = func(ctx context.Context, paymentIntentID string) (*stripe.Refund, error) {
+		_ = ctx
+		return refundapi.New(&stripe.RefundParams{
+			PaymentIntent: stripe.String(paymentIntentID),
+			Reason:        stripe.String(string(stripe.RefundReasonRequestedByCustomer)),
+		})
+	}
 )
 
 type Service struct {
-	repo *Repository
+	repo           *Repository
+	storeService   *store.Service
+	profileService *profile.Service
 }
 
 func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
+}
+
+func (s *Service) SetDependencies(storeService *store.Service, profileService *profile.Service) {
+	s.storeService = storeService
+	s.profileService = profileService
 }
 
 func (s *Service) DeleteByAccountID(ctx context.Context, accountID int) error {
@@ -56,6 +110,100 @@ func (s *Service) Delete(ctx context.Context, accountID int, id uuid.UUID) error
 	if lic.AccountID != accountID {
 		return ErrForbidden
 	}
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *Service) Refund(ctx context.Context, accountID int, id uuid.UUID) error {
+	lic, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrLicenceNotFound
+		}
+		return err
+	}
+	if lic.AccountID != accountID {
+		return ErrForbidden
+	}
+
+	if s.storeService == nil || s.profileService == nil {
+		return fmt.Errorf("refund dependencies not configured")
+	}
+
+	if strings.TrimSpace(lic.Transaction) == "" {
+		return fmt.Errorf("licence transaction is missing")
+	}
+
+	sess, err := retrieveCheckoutSession(ctx, lic.Transaction)
+	if err != nil {
+		return fmt.Errorf("retrieve checkout session: %w", err)
+	}
+
+	if sess.Subscription == nil || sess.Subscription.ID == "" {
+		return fmt.Errorf("checkout session %s does not contain a subscription", lic.Transaction)
+	}
+
+	if _, err := cancelSubscription(ctx, sess.Subscription.ID); err != nil {
+		return fmt.Errorf("cancel stripe subscription: %w", err)
+	}
+
+	paymentIntentID := ""
+	chargeID := ""
+	if sess.PaymentIntent != nil {
+		paymentIntentID = sess.PaymentIntent.ID
+	}
+	if paymentIntentID == "" {
+		sub, err := retrieveSubscriptionForRefund(ctx, sess.Subscription.ID)
+		if err != nil {
+			return fmt.Errorf("retrieve stripe subscription for refund: %w", err)
+		}
+		if sub != nil && sub.LatestInvoice != nil && sub.LatestInvoice.Payments != nil {
+			for _, invPayment := range sub.LatestInvoice.Payments.Data {
+				if invPayment == nil || invPayment.Payment == nil {
+					continue
+				}
+				if invPayment.Payment.PaymentIntent != nil && invPayment.Payment.PaymentIntent.ID != "" {
+					paymentIntentID = invPayment.Payment.PaymentIntent.ID
+					break
+				}
+				if chargeID == "" && invPayment.Payment.Charge != nil && invPayment.Payment.Charge.ID != "" {
+					chargeID = invPayment.Payment.Charge.ID
+				}
+			}
+		}
+	}
+
+	if paymentIntentID != "" {
+		if _, err := createRefund(ctx, paymentIntentID); err != nil {
+			return fmt.Errorf("create stripe refund: %w", err)
+		}
+	} else if chargeID != "" {
+		if _, err := refundapi.New(&stripe.RefundParams{
+			Charge: stripe.String(chargeID),
+			Reason: stripe.String(string(stripe.RefundReasonRequestedByCustomer)),
+		}); err != nil {
+			return fmt.Errorf("create stripe refund from charge: %w", err)
+		}
+	}
+
+	st, err := s.storeService.FindByLicenceID(ctx, id)
+	if err != nil {
+		if errors.Is(err, store.ErrStoreNotFound) {
+			return s.repo.Delete(ctx, id)
+		}
+		return err
+	}
+	if st.BuyerID != accountID {
+		return ErrForbidden
+	}
+
+	if err := s.profileService.DeleteByStoreID(ctx, st.StoreID); err != nil {
+		return err
+	}
+
+	if err := s.storeService.DeleteByID(ctx, st.StoreID); err != nil {
+		return err
+	}
+
 	return s.repo.Delete(ctx, id)
 }
 
@@ -140,4 +288,39 @@ func (s *Service) CreatePaymentLink(ctx context.Context, accountID int, customer
 	}
 
 	return sess.URL, nil
+}
+
+func (s *Service) DeleteByStripeSubscriptionID(ctx context.Context, subscriptionID string) error {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	if subscriptionID == "" {
+		return fmt.Errorf("missing subscription ID")
+	}
+
+	// Fallback for any row that might already store subscription ID directly.
+	if lic, err := s.repo.FindByTransaction(ctx, subscriptionID); err == nil {
+		return s.repo.Delete(ctx, lic.LicenceID)
+	} else if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+
+	sessions, err := listCheckoutSessionsBySubscription(ctx, subscriptionID)
+	if err != nil {
+		return fmt.Errorf("list checkout sessions by subscription: %w", err)
+	}
+
+	for _, sess := range sessions {
+		if sess == nil || sess.ID == "" {
+			continue
+		}
+		lic, err := s.repo.FindByTransaction(ctx, sess.ID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				continue
+			}
+			return err
+		}
+		return s.repo.Delete(ctx, lic.LicenceID)
+	}
+
+	return nil
 }

--- a/app/internal/license/service_test.go
+++ b/app/internal/license/service_test.go
@@ -9,7 +9,10 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stripe/stripe-go/v84"
 
+	"tili/app/internal/profile"
+	"tili/app/internal/store"
 	"tili/app/pkg/db"
 )
 
@@ -123,6 +126,181 @@ func TestService_DeleteByAccountID_Success(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestService_Refund_Success(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	origRetrieveCheckoutSession := retrieveCheckoutSession
+	origCancelSubscription := cancelSubscription
+	origCreateRefund := createRefund
+	t.Cleanup(func() {
+		retrieveCheckoutSession = origRetrieveCheckoutSession
+		cancelSubscription = origCancelSubscription
+		createRefund = origCreateRefund
+	})
+
+	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
+		assert.Equal(t, "cs_test_123", sessionID)
+		return &stripe.CheckoutSession{
+			Subscription: &stripe.Subscription{ID: "sub_123"},
+			PaymentIntent: &stripe.PaymentIntent{ID: "pi_123"},
+		}, nil
+	}
+	cancelSubscription = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_123", subscriptionID)
+		return &stripe.Subscription{ID: subscriptionID}, nil
+	}
+	createRefund = func(ctx context.Context, paymentIntentID string) (*stripe.Refund, error) {
+		assert.Equal(t, "pi_123", paymentIntentID)
+		return &stripe.Refund{ID: "re_123"}, nil
+	}
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	storeSvc := store.NewService(store.NewRepository(&db.Db{DB: bunDB}))
+	profileSvc := profile.NewService(profile.NewRepository(&db.Db{DB: bunDB}))
+	svc := NewService(repo)
+	svc.SetDependencies(storeSvc, profileSvc)
+
+	licID := uuid.New()
+	storeID := 10
+	storeRows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation", "numero_tva", "siret"}).AddRow(storeID, "Refund Store", 1, licID, time.Now(), "", "")
+	licRows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "cs_test_123")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnRows(licRows)
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(storeRows)
+	mock.ExpectExec(`^DELETE FROM "profile" AS "p" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "store" AS "s" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := svc.Refund(context.Background(), 1, licID)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_Refund_Success_ResolvePaymentIntentFromSubscription(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	origRetrieveCheckoutSession := retrieveCheckoutSession
+	origRetrieveSubscriptionForRefund := retrieveSubscriptionForRefund
+	origCancelSubscription := cancelSubscription
+	origCreateRefund := createRefund
+	t.Cleanup(func() {
+		retrieveCheckoutSession = origRetrieveCheckoutSession
+		retrieveSubscriptionForRefund = origRetrieveSubscriptionForRefund
+		cancelSubscription = origCancelSubscription
+		createRefund = origCreateRefund
+	})
+
+	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
+		assert.Equal(t, "cs_test_456", sessionID)
+		return &stripe.CheckoutSession{
+			Subscription: &stripe.Subscription{ID: "sub_456"},
+		}, nil
+	}
+	retrieveSubscriptionForRefund = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_456", subscriptionID)
+		return &stripe.Subscription{
+			LatestInvoice: &stripe.Invoice{
+				Payments: &stripe.InvoicePaymentList{
+					Data: []*stripe.InvoicePayment{
+						{
+							Payment: &stripe.InvoicePaymentPayment{
+								PaymentIntent: &stripe.PaymentIntent{ID: "pi_456"},
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	}
+	cancelSubscription = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_456", subscriptionID)
+		return &stripe.Subscription{ID: subscriptionID}, nil
+	}
+	createRefund = func(ctx context.Context, paymentIntentID string) (*stripe.Refund, error) {
+		assert.Equal(t, "pi_456", paymentIntentID)
+		return &stripe.Refund{ID: "re_456"}, nil
+	}
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	storeSvc := store.NewService(store.NewRepository(&db.Db{DB: bunDB}))
+	profileSvc := profile.NewService(profile.NewRepository(&db.Db{DB: bunDB}))
+	svc := NewService(repo)
+	svc.SetDependencies(storeSvc, profileSvc)
+
+	licID := uuid.New()
+	storeID := 11
+	storeRows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation", "numero_tva", "siret"}).AddRow(storeID, "Refund Store 2", 1, licID, time.Now(), "", "")
+	licRows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "cs_test_456")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnRows(licRows)
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(storeRows)
+	mock.ExpectExec(`^DELETE FROM "profile" AS "p" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "store" AS "s" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := svc.Refund(context.Background(), 1, licID)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_Refund_Success_NoPaymentReference(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	origRetrieveCheckoutSession := retrieveCheckoutSession
+	origRetrieveSubscriptionForRefund := retrieveSubscriptionForRefund
+	origCancelSubscription := cancelSubscription
+	origCreateRefund := createRefund
+	t.Cleanup(func() {
+		retrieveCheckoutSession = origRetrieveCheckoutSession
+		retrieveSubscriptionForRefund = origRetrieveSubscriptionForRefund
+		cancelSubscription = origCancelSubscription
+		createRefund = origCreateRefund
+	})
+
+	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
+		assert.Equal(t, "cs_test_789", sessionID)
+		return &stripe.CheckoutSession{
+			Subscription: &stripe.Subscription{ID: "sub_789"},
+		}, nil
+	}
+	retrieveSubscriptionForRefund = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_789", subscriptionID)
+		return &stripe.Subscription{LatestInvoice: &stripe.Invoice{}}, nil
+	}
+	cancelSubscription = func(ctx context.Context, subscriptionID string) (*stripe.Subscription, error) {
+		assert.Equal(t, "sub_789", subscriptionID)
+		return &stripe.Subscription{ID: subscriptionID}, nil
+	}
+	createRefund = func(ctx context.Context, paymentIntentID string) (*stripe.Refund, error) {
+		assert.Fail(t, "createRefund should not be called when there is no payment reference")
+		return nil, nil
+	}
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	storeSvc := store.NewService(store.NewRepository(&db.Db{DB: bunDB}))
+	profileSvc := profile.NewService(profile.NewRepository(&db.Db{DB: bunDB}))
+	svc := NewService(repo)
+	svc.SetDependencies(storeSvc, profileSvc)
+
+	licID := uuid.New()
+	storeID := 12
+	storeRows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation", "numero_tva", "siret"}).AddRow(storeID, "Refund Store 3", 1, licID, time.Now(), "", "")
+	licRows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "cs_test_789")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnRows(licRows)
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(storeRows)
+	mock.ExpectExec(`^DELETE FROM "profile" AS "p" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "store" AS "s" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := svc.Refund(context.Background(), 1, licID)
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestService_Create_Success(t *testing.T) {
 	bunDB, mock := setupMockDB(t)
 	defer bunDB.Close()
@@ -140,5 +318,60 @@ func TestService_Create_Success(t *testing.T) {
 		assert.True(t, lic.IsActive)
 		assert.WithinDuration(t, time.Now().Add(30*24*time.Hour), lic.Expiration, time.Second)
 	}
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_DeleteByStripeSubscriptionID_Success(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	origListCheckoutSessionsBySubscription := listCheckoutSessionsBySubscription
+	t.Cleanup(func() {
+		listCheckoutSessionsBySubscription = origListCheckoutSessionsBySubscription
+	})
+
+	listCheckoutSessionsBySubscription = func(ctx context.Context, subscriptionID string) ([]*stripe.CheckoutSession, error) {
+		assert.Equal(t, "sub_123", subscriptionID)
+		return []*stripe.CheckoutSession{{ID: "cs_test_123"}}, nil
+	}
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	svc := NewService(repo)
+
+	licID := uuid.New()
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(transaction = .+\)$`).WillReturnError(sql.ErrNoRows)
+	rows := sqlmock.NewRows([]string{"licence_id", "account_id", "transaction"}).AddRow(licID, 1, "cs_test_123")
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(transaction = .+\)$`).WillReturnRows(rows)
+	mock.ExpectExec(`^DELETE FROM "licence" AS "l" WHERE \(licence_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := svc.DeleteByStripeSubscriptionID(context.Background(), "sub_123")
+
+	assert.NoError(t, err)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_DeleteByStripeSubscriptionID_NotFound(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	origListCheckoutSessionsBySubscription := listCheckoutSessionsBySubscription
+	t.Cleanup(func() {
+		listCheckoutSessionsBySubscription = origListCheckoutSessionsBySubscription
+	})
+
+	listCheckoutSessionsBySubscription = func(ctx context.Context, subscriptionID string) ([]*stripe.CheckoutSession, error) {
+		assert.Equal(t, "sub_404", subscriptionID)
+		return []*stripe.CheckoutSession{{ID: "cs_unknown"}}, nil
+	}
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	svc := NewService(repo)
+
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(transaction = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "licence" AS "l" WHERE \(transaction = .+\)$`).WillReturnError(sql.ErrNoRows)
+
+	err := svc.DeleteByStripeSubscriptionID(context.Background(), "sub_404")
+
+	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/app/internal/license/service_test.go
+++ b/app/internal/license/service_test.go
@@ -142,7 +142,7 @@ func TestService_Refund_Success(t *testing.T) {
 	retrieveCheckoutSession = func(ctx context.Context, sessionID string) (*stripe.CheckoutSession, error) {
 		assert.Equal(t, "cs_test_123", sessionID)
 		return &stripe.CheckoutSession{
-			Subscription: &stripe.Subscription{ID: "sub_123"},
+			Subscription:  &stripe.Subscription{ID: "sub_123"},
 			PaymentIntent: &stripe.PaymentIntent{ID: "pi_123"},
 		}, nil
 	}

--- a/app/internal/store/repository.go
+++ b/app/internal/store/repository.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/redis/go-redis/v9"
 
+	"github.com/google/uuid"
+
 	"github.com/uptrace/bun"
 )
 
@@ -75,6 +77,20 @@ func (r *Repository) FindByBuyerID(ctx context.Context, buyerID int) ([]Store, e
 	}
 	_ = cache.Set(ctx, r.cache, key, &stores, cache.DefaultTTL)
 	return stores, nil
+}
+
+func (r *Repository) FindByLicenceID(ctx context.Context, licenceID uuid.UUID) (*Store, error) {
+	key := fmt.Sprintf("store:licence:%s", licenceID.String())
+	store := &Store{}
+	if hit, err := cache.Get(ctx, r.cache, key, store); err == nil && hit {
+		return store, nil
+	}
+	err := r.db.NewSelect().Model(store).Where("licence_id = ?", licenceID).Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	_ = cache.Set(ctx, r.cache, key, store, cache.DefaultTTL)
+	return store, nil
 }
 
 func (r *Repository) Delete(ctx context.Context, id int) error {

--- a/app/internal/store/repository_test.go
+++ b/app/internal/store/repository_test.go
@@ -95,6 +95,26 @@ func TestRepository_FindByBuyerID(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestRepository_FindByLicenceID(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+	repo := NewRepository(&db.Db{DB: bunDB})
+
+	licenceID := uuid.New()
+	rows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation"}).AddRow(1, "Licence Store", 2, licenceID, time.Now())
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(rows)
+
+	ctx := context.Background()
+	st, err := repo.FindByLicenceID(ctx, licenceID)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, st) {
+		assert.Equal(t, "Licence Store", st.Name)
+		assert.Equal(t, licenceID, st.LicenceID)
+	}
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestRepository_Delete(t *testing.T) {
 	bunDB, mock := setupMockDB(t)
 	defer bunDB.Close()

--- a/app/internal/store/service.go
+++ b/app/internal/store/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+
+	"github.com/google/uuid"
 )
 
 var (
@@ -44,6 +46,17 @@ func (s *Service) FindByBuyerID(ctx context.Context, buyerID int) ([]Store, erro
 	return s.repo.FindByBuyerID(ctx, buyerID)
 }
 
+func (s *Service) FindByLicenceID(ctx context.Context, licenceID uuid.UUID) (*Store, error) {
+	st, err := s.repo.FindByLicenceID(ctx, licenceID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrStoreNotFound
+		}
+		return nil, err
+	}
+	return st, nil
+}
+
 func (s *Service) FindAll(ctx context.Context) ([]*Store, error) {
 	stores, err := s.repo.FindAll(ctx)
 	if err != nil {
@@ -60,6 +73,10 @@ func (s *Service) Delete(ctx context.Context, id int) error {
 		}
 		return err
 	}
+	return s.repo.Delete(ctx, id)
+}
+
+func (s *Service) DeleteByID(ctx context.Context, id int) error {
 	return s.repo.Delete(ctx, id)
 }
 

--- a/app/internal/store/service_test.go
+++ b/app/internal/store/service_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
@@ -158,6 +159,41 @@ func TestService_FindByBuyerID_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, stores, 1)
 	assert.Equal(t, "Buyer Store", stores[0].Name)
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_FindByLicenceID_Success(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	svc := NewService(repo)
+
+	licenceID := uuid.New()
+	rows := sqlmock.NewRows([]string{"store_id", "name", "buyer_id", "licence_id", "date_creation"}).AddRow(1, "Licence Store", 12, licenceID, time.Now())
+	mock.ExpectQuery(`^SELECT .* FROM "store" AS "s" WHERE \(licence_id = .+\)$`).WillReturnRows(rows)
+
+	store, err := svc.FindByLicenceID(context.Background(), licenceID)
+
+	assert.NoError(t, err)
+	if assert.NotNil(t, store) {
+		assert.Equal(t, licenceID, store.LicenceID)
+	}
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestService_DeleteByID_Success(t *testing.T) {
+	bunDB, mock := setupMockDB(t)
+	defer bunDB.Close()
+
+	repo := NewRepository(&db.Db{DB: bunDB})
+	svc := NewService(repo)
+
+	mock.ExpectExec(`^DELETE FROM "store" AS "s" WHERE \(store_id = .+\)$`).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err := svc.DeleteByID(context.Background(), 1)
+
+	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
This pull request introduces Redis caching into the repositories for several core modules (`account`, `catalog`, `categorie`, `item`) to improve performance and reduce database load. It modifies repository constructors to accept a Redis client, implements cache reads/writes for key data access methods, and ensures cache invalidation on mutations. Additionally, it updates the application wiring to provide the Redis client to each repository and makes minor test and model adjustments.

**Caching Integration and Repository Updates:**

* Added Redis caching to the `account`, `catalog`, `categorie`, and `item` repositories: constructors now accept a Redis client, and key read methods (`FindAll`, `FindByID`, etc.) first attempt to fetch from cache, falling back to the database and updating the cache as needed. Mutating methods (`Create`, `Update`, `Delete`) invalidate relevant cache entries using prefix deletes. [[1]](diffhunk://#diff-cf77439708ac253a13d82ca953aff5c32bf49f314e727f90173da689ba8f1893R6-R29) [[2]](diffhunk://#diff-cf77439708ac253a13d82ca953aff5c32bf49f314e727f90173da689ba8f1893R53) [[3]](diffhunk://#diff-cf77439708ac253a13d82ca953aff5c32bf49f314e727f90173da689ba8f1893R62) [[4]](diffhunk://#diff-96274a2867ae4f5ffc4f77fe7f6bbd0f49320cf89a7363c9ba61e43c430927d9R5-R86) [[5]](diffhunk://#diff-96274a2867ae4f5ffc4f77fe7f6bbd0f49320cf89a7363c9ba61e43c430927d9R106) [[6]](diffhunk://#diff-1fdf5cf30a52366e7dd87549bbb924b020c212d0f995f55b32a3c0c6d33eba06R5-R74) [[7]](diffhunk://#diff-1fdf5cf30a52366e7dd87549bbb924b020c212d0f995f55b32a3c0c6d33eba06R89) [[8]](diffhunk://#diff-1fdf5cf30a52366e7dd87549bbb924b020c212d0f995f55b32a3c0c6d33eba06R100) [[9]](diffhunk://#diff-1fdf5cf30a52366e7dd87549bbb924b020c212d0f995f55b32a3c0c6d33eba06R111) [[10]](diffhunk://#diff-308a806c9ea8ad058f274700f704f2d6bb7c6449abfa89d448e8ec4dae833429R5-R27) [[11]](diffhunk://#diff-308a806c9ea8ad058f274700f704f2d6bb7c6449abfa89d448e8ec4dae833429R38-R122) [[12]](diffhunk://#diff-308a806c9ea8ad058f274700f704f2d6bb7c6449abfa89d448e8ec4dae833429R149)

* The main application (`app/cmd/main.go`) is updated to initialize a Redis client and pass it to all relevant repositories. [[1]](diffhunk://#diff-52958ec0b155f1c1b8538b1c520eda01b88d8da814f3e43982b4327f1d544a80R16) [[2]](diffhunk://#diff-52958ec0b155f1c1b8538b1c520eda01b88d8da814f3e43982b4327f1d544a80R40-R73)

**Dependency and Model Adjustments:**

* Added new dependencies for Redis and related packages in `go.mod`. [[1]](diffhunk://#diff-069b9bb7928c94d23a25c5359ed64d0e2365aba57fa4930135ddae7b8b742e2fR30) [[2]](diffhunk://#diff-069b9bb7928c94d23a25c5359ed64d0e2365aba57fa4930135ddae7b8b742e2fR63-R71)
* Made `catalogID` exported in the `catalog` model to ensure proper marshaling/unmarshaling and cache usage.

**Testing and API Improvements:**

* Updated repository tests for `catalog` to include `catalog_id` in test rows and queries, aligning with the new model and cache logic. [[1]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL28-R31) [[2]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL55-R56) [[3]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL71-R75) [[4]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL93-R94) [[5]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL147-R148)
* Added a new route for license refunds in the license handler.