### PR TITLE
Update logic, for catalogue and categories to make them private to a shop

### DIFF
--- a/app/internal/catalog/handler.go
+++ b/app/internal/catalog/handler.go
@@ -20,20 +20,20 @@ func NewHandler(service *Service) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(router *gin.Engine) {
-	catalogRoutes := router.Group("/store/:store_id/catalog")
+	catalogRoutes := router.Group("/catalog")
 	{
 		protected := catalogRoutes.Group("")
 		protected.Use(middleware.ProfileAuthMiddleware())
 		{
-			protected.GET("", h.GetAll)      // GET /store/:store_id/catalog
-			protected.GET("/:id", h.GetByID) // GET /store/:store_id/catalog/:id
+			protected.GET("/store/:store_id", h.GetAll) // GET /catalog/store/:store_id
+			protected.GET("/:id", h.GetByID)            // GET /catalog/:id
 
 			managerRoutes := protected.Group("")
 			managerRoutes.Use(middleware.LevelAccessRequired(token.Manager))
 			{
-				managerRoutes.POST("", h.Create)       // POST /store/:store_id/catalog
-				managerRoutes.PUT("/:id", h.Update)    // PUT /store/:store_id/catalog/:id
-				managerRoutes.DELETE("/:id", h.Delete) // DELETE /store/:store_id/catalog/:id
+				managerRoutes.POST("/store/:store_id", h.Create) // POST /catalog/store/:store_id
+				managerRoutes.PUT("/:id", h.Update)              // PUT /catalog/:id
+				managerRoutes.DELETE("/:id", h.Delete)           // DELETE /catalog/:id
 			}
 		}
 	}
@@ -61,7 +61,7 @@ func parseStoreID(c *gin.Context) (int, bool) {
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /store/{store_id}/catalog [post]
+// @Router       /catalog/store/{store_id} [post]
 func (h *Handler) Create(c *gin.Context) {
 	storeID, ok := parseStoreID(c)
 	if !ok {
@@ -91,7 +91,7 @@ func (h *Handler) Create(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /store/{store_id}/catalog [get]
+// @Router       /catalog/store/{store_id} [get]
 func (h *Handler) GetAll(c *gin.Context) {
 	storeID, ok := parseStoreID(c)
 	if !ok {
@@ -116,8 +116,8 @@ func (h *Handler) GetAll(c *gin.Context) {
 // @Success      200  {object}  catalog
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
-// @Failure      404  {object}  map[string]interface{}
-// @Router       /store/{store_id}/catalog/{id} [get]
+// @Failure      500  {object}  map[string]interface{}
+// @Router       /catalog/{id} [get]
 func (h *Handler) GetByID(c *gin.Context) {
 	storeID, ok := parseStoreID(c)
 	if !ok {
@@ -152,10 +152,10 @@ func (h *Handler) GetByID(c *gin.Context) {
 // @Param        body     body      catalogUpdate true "catalog update payload"
 // @Success      200  {object}  catalog
 // @Failure      400  {object}  map[string]interface{}
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
-// @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /store/{store_id}/catalog/{id} [put]
+// @Router       /catalog/{id} [put]
 func (h *Handler) Update(c *gin.Context) {
 	storeID, ok := parseStoreID(c)
 	if !ok {
@@ -193,10 +193,10 @@ func (h *Handler) Update(c *gin.Context) {
 // @Param        id       path      int  true "catalog ID" example(1)
 // @Success      204  {object}  nil
 // @Failure      400  {object}  map[string]interface{}
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
-// @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /store/{store_id}/catalog/{id} [delete]
+// @Router       /catalog/{id} [delete]
 func (h *Handler) Delete(c *gin.Context) {
 	storeID, ok := parseStoreID(c)
 	if !ok {

--- a/app/internal/catalog/handler.go
+++ b/app/internal/catalog/handler.go
@@ -20,45 +20,59 @@ func NewHandler(service *Service) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(router *gin.Engine) {
-	catalogRoutes := router.Group("/catalog")
+	catalogRoutes := router.Group("/store/:store_id/catalog")
 	{
 		protected := catalogRoutes.Group("")
 		protected.Use(middleware.ProfileAuthMiddleware())
 		{
-			protected.GET("", h.GetAll)      // GET /catalog
-			protected.GET("/:id", h.GetByID) // GET /catalog/:id
+			protected.GET("", h.GetAll)      // GET /store/:store_id/catalog
+			protected.GET("/:id", h.GetByID) // GET /store/:store_id/catalog/:id
 
 			managerRoutes := protected.Group("")
 			managerRoutes.Use(middleware.LevelAccessRequired(token.Manager))
 			{
-				managerRoutes.POST("", h.Create)       // POST /catalog
-				managerRoutes.PUT("/:id", h.Update)    // PUT /catalog/:id
-				managerRoutes.DELETE("/:id", h.Delete) // DELETE /catalog/:id
+				managerRoutes.POST("", h.Create)       // POST /store/:store_id/catalog
+				managerRoutes.PUT("/:id", h.Update)    // PUT /store/:store_id/catalog/:id
+				managerRoutes.DELETE("/:id", h.Delete) // DELETE /store/:store_id/catalog/:id
 			}
 		}
 	}
 }
 
-// Create adds a new catalog
+func parseStoreID(c *gin.Context) (int, bool) {
+	storeID, err := strconv.Atoi(c.Param("store_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid store_id"})
+		return 0, false
+	}
+	return storeID, true
+}
+
+// Create adds a new catalog for a store
 // @Summary      Create a catalog
-// @Description  Creates a new catalog in the system
+// @Description  Creates a new catalog in the system for a given store
 // @Tags         catalog
 // @Accept       json
 // @Produce      json
 // @Security     ProfileToken
-// @Param        body body      catalogUpdate true "catalog payload"
+// @Param        store_id path      int           true "Store ID"  example(1)
+// @Param        body     body      catalogUpdate true "catalog payload"
 // @Success      201  {object}  catalog
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog [post]
+// @Router       /store/{store_id}/catalog [post]
 func (h *Handler) Create(c *gin.Context) {
+	storeID, ok := parseStoreID(c)
+	if !ok {
+		return
+	}
 	var input catalogUpdate
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	catalog, err := h.service.Create(c.Request.Context(), input)
+	catalog, err := h.service.Create(c.Request.Context(), storeID, input)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -66,18 +80,24 @@ func (h *Handler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, catalog)
 }
 
-// GetAll retrieves the list of all catalogs
+// GetAll retrieves all catalogs for a store
 // @Summary      List catalogs
-// @Description  Retrieves the complete list of catalogs
+// @Description  Retrieves the complete list of catalogs for a store
 // @Tags         catalog
 // @Produce      json
 // @Security     ProfileToken
+// @Param        store_id path      int  true "Store ID"  example(1)
 // @Success      200  {array}   catalog
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog [get]
+// @Router       /store/{store_id}/catalog [get]
 func (h *Handler) GetAll(c *gin.Context) {
-	catalogs, err := h.service.GetAll(c.Request.Context())
+	storeID, ok := parseStoreID(c)
+	if !ok {
+		return
+	}
+	catalogs, err := h.service.GetAll(c.Request.Context(), storeID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -85,25 +105,30 @@ func (h *Handler) GetAll(c *gin.Context) {
 	c.JSON(http.StatusOK, catalogs)
 }
 
-// GetByID retrieves a catalog by its ID
+// GetByID retrieves a catalog by its ID within a store
 // @Summary      Retrieve a catalog
-// @Description  Retrieves the details of a catalog using its ID
+// @Description  Retrieves the details of a catalog using its ID within a store
 // @Tags         catalog
 // @Produce      json
 // @Security     ProfileToken
-// @Param        id   path      int  true  "catalog ID"  example(1)
+// @Param        store_id path      int  true "Store ID"   example(1)
+// @Param        id       path      int  true "catalog ID" example(1)
 // @Success      200  {object}  catalog
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
-// @Router       /catalog/{id} [get]
+// @Router       /store/{store_id}/catalog/{id} [get]
 func (h *Handler) GetByID(c *gin.Context) {
+	storeID, ok := parseStoreID(c)
+	if !ok {
+		return
+	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	catalog, err := h.service.GetByID(c.Request.Context(), id)
+	catalog, err := h.service.GetByID(c.Request.Context(), id, storeID)
 	if err != nil {
 		if errors.Is(err, ErrCatalogNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "catalog not found"})
@@ -115,22 +140,27 @@ func (h *Handler) GetByID(c *gin.Context) {
 	c.JSON(http.StatusOK, catalog)
 }
 
-// Update modifies an existing catalog
+// Update modifies an existing catalog within a store
 // @Summary      Update a catalog
-// @Description  Modifies the information of an existing catalog via its ID
+// @Description  Modifies the information of an existing catalog via its ID within a store
 // @Tags         catalog
 // @Accept       json
 // @Produce      json
 // @Security     ProfileToken
-// @Param        id   path      int             true "catalog ID"  example(1)
-// @Param        body body      catalogUpdate true "catalog update payload"
+// @Param        store_id path      int           true "Store ID"   example(1)
+// @Param        id       path      int           true "catalog ID" example(1)
+// @Param        body     body      catalogUpdate true "catalog update payload"
 // @Success      200  {object}  catalog
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{id} [put]
+// @Router       /store/{store_id}/catalog/{id} [put]
 func (h *Handler) Update(c *gin.Context) {
+	storeID, ok := parseStoreID(c)
+	if !ok {
+		return
+	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
@@ -141,33 +171,43 @@ func (h *Handler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	catalog, err := h.service.Update(c.Request.Context(), id, input)
+	catalog, err := h.service.Update(c.Request.Context(), id, storeID, input)
 	if err != nil {
+		if errors.Is(err, ErrCatalogNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "catalog not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusOK, catalog)
 }
 
-// Delete removes a catalog
+// Delete removes a catalog from a store
 // @Summary      Delete a catalog
-// @Description  Deletes a catalog from the system via its ID
+// @Description  Deletes a catalog from the system via its ID within a store
 // @Tags         catalog
 // @Produce      json
 // @Security     ProfileToken
-// @Param        id   path      int  true  "catalog ID"  example(1)
+// @Param        store_id path      int  true "Store ID"   example(1)
+// @Param        id       path      int  true "catalog ID" example(1)
 // @Success      204  {object}  nil
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
+// @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{id} [delete]
+// @Router       /store/{store_id}/catalog/{id} [delete]
 func (h *Handler) Delete(c *gin.Context) {
+	storeID, ok := parseStoreID(c)
+	if !ok {
+		return
+	}
 	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	err = h.service.Delete(c.Request.Context(), id)
+	err = h.service.Delete(c.Request.Context(), id, storeID)
 	if err != nil {
 		if errors.Is(err, ErrCatalogNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "catalog not found"})

--- a/app/internal/catalog/handler_test.go
+++ b/app/internal/catalog/handler_test.go
@@ -37,9 +37,9 @@ func TestCatalogHandler_Create_BadJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCatalogHandler(t)
-	r.POST("/catalog", h.Create)
+	r.POST("/store/:store_id/catalog", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/catalog", bytes.NewBufferString("{"))
+	req := httptest.NewRequest(http.MethodPost, "/store/1/catalog", bytes.NewBufferString("{"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -52,9 +52,9 @@ func TestCatalogHandler_GetByID_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCatalogHandler(t)
-	r.GET("/catalog/:id", h.GetByID)
+	r.GET("/store/:store_id/catalog/:id", h.GetByID)
 
-	req := httptest.NewRequest(http.MethodGet, "/catalog/abc", nil)
+	req := httptest.NewRequest(http.MethodGet, "/store/1/catalog/abc", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -66,11 +66,11 @@ func TestCatalogHandler_GetByID_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, mock := setupCatalogHandler(t)
-	r.GET("/catalog/:id", h.GetByID)
+	r.GET("/store/:store_id/catalog/:id", h.GetByID)
 
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\) AND \(c\.store_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	req := httptest.NewRequest(http.MethodGet, "/catalog/1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/store/1/catalog/1", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -83,9 +83,9 @@ func TestCatalogHandler_Update_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCatalogHandler(t)
-	r.PUT("/catalog/:id", h.Update)
+	r.PUT("/store/:store_id/catalog/:id", h.Update)
 
-	req := httptest.NewRequest(http.MethodPut, "/catalog/abc", bytes.NewBufferString("{}"))
+	req := httptest.NewRequest(http.MethodPut, "/store/1/catalog/abc", bytes.NewBufferString("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -98,9 +98,9 @@ func TestCatalogHandler_Delete_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCatalogHandler(t)
-	r.DELETE("/catalog/:id", h.Delete)
+	r.DELETE("/store/:store_id/catalog/:id", h.Delete)
 
-	req := httptest.NewRequest(http.MethodDelete, "/catalog/abc", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/store/1/catalog/abc", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -112,12 +112,12 @@ func TestCatalogHandler_GetAll_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, mock := setupCatalogHandler(t)
-	r.GET("/catalog", h.GetAll)
+	r.GET("/store/:store_id/catalog", h.GetAll)
 
-	rows := sqlmock.NewRows([]string{"name", "description"}).AddRow("C1", "D1")
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c"$`).WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).AddRow("C1", "D1", 1)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.store_id = .+\)$`).WillReturnRows(rows)
 
-	req := httptest.NewRequest(http.MethodGet, "/catalog", nil)
+	req := httptest.NewRequest(http.MethodGet, "/store/1/catalog", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)

--- a/app/internal/catalog/model.go
+++ b/app/internal/catalog/model.go
@@ -10,9 +10,11 @@ type catalog struct {
 	catalogID   int    `bun:"catalog_id,pk,autoincrement" json:"catalog_id"  example:"1"`
 	Name        string `bun:"name,notnull"                json:"name"        example:"Winter 2026 Collection"`
 	Description string `bun:"description"                 json:"description" example:"All items available for the winter 2026 season"`
+	StoreID     int    `bun:"store_id,notnull"            json:"store_id"    example:"1"`
 }
 
 type catalogUpdate struct {
 	Name        *string `json:"name"        example:"Winter 2026 Collection"`
 	Description *string `json:"description" example:"All items available for the winter 2026 season"`
 }
+

--- a/app/internal/catalog/model.go
+++ b/app/internal/catalog/model.go
@@ -17,4 +17,3 @@ type catalogUpdate struct {
 	Name        *string `json:"name"        example:"Winter 2026 Collection"`
 	Description *string `json:"description" example:"All items available for the winter 2026 season"`
 }
-

--- a/app/internal/catalog/repository.go
+++ b/app/internal/catalog/repository.go
@@ -2,6 +2,7 @@ package catalog
 
 import (
 	"context"
+	"fmt"
 
 	"tili/app/pkg/cache"
 	"tili/app/pkg/db"
@@ -26,17 +27,17 @@ func NewRepository(d *db.Db, cacheClients ...*redis.Client) *Repository {
 
 func (r *Repository) Create(ctx context.Context, c *catalog) error {
 	_, err := r.db.NewInsert().Model(c).Exec(ctx)
-	_ = cache.DeletePrefix(ctx, r.cache, "catalog:")
+	_ = cache.DeletePrefix(ctx, r.cache, fmt.Sprintf("catalog:store:%d:", c.StoreID))
 	return err
 }
 
-func (r *Repository) FindAll(ctx context.Context) ([]catalog, error) {
-	const key = "catalog:all"
+func (r *Repository) FindAll(ctx context.Context, storeID int) ([]catalog, error) {
+	key := fmt.Sprintf("catalog:store:%d:all", storeID)
 	var catalogs []catalog
 	if hit, err := cache.Get(ctx, r.cache, key, &catalogs); err == nil && hit {
 		return catalogs, nil
 	}
-	err := r.db.NewSelect().Model(&catalogs).Scan(ctx)
+	err := r.db.NewSelect().Model(&catalogs).Where("c.store_id = ?", storeID).Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -44,46 +45,64 @@ func (r *Repository) FindAll(ctx context.Context) ([]catalog, error) {
 	return catalogs, err
 }
 
-func (r *Repository) FindByID(ctx context.Context, id int) (*catalog, error) {
+func (r *Repository) FindByID(ctx context.Context, id int, storeID int) (*catalog, error) {
 	c := new(catalog)
-	err := r.db.NewSelect().Model(c).Where("c.catalog_id = ?", id).Scan(ctx)
+	err := r.db.NewSelect().Model(c).
+		Where("c.catalog_id = ?", id).
+		Where("c.store_id = ?", storeID).
+		Scan(ctx)
 	return c, err
 }
 
-func (r *Repository) FindByName(ctx context.Context, name string) (*catalog, error) {
+func (r *Repository) FindByName(ctx context.Context, name string, storeID int) (*catalog, error) {
 	c := new(catalog)
-	err := r.db.NewSelect().Model(c).Where("c.name = ?", name).Scan(ctx)
+	err := r.db.NewSelect().Model(c).
+		Where("c.name = ?", name).
+		Where("c.store_id = ?", storeID).
+		Scan(ctx)
 	return c, err
 }
 
-func (r *Repository) DeleteByID(ctx context.Context, id int) error {
-	_, err := r.db.NewDelete().Model(&catalog{}).Where("catalog_id = ?", id).Exec(ctx)
-	_ = cache.DeletePrefix(ctx, r.cache, "catalog:")
+func (r *Repository) DeleteByID(ctx context.Context, id int, storeID int) error {
+	_, err := r.db.NewDelete().Model(&catalog{}).
+		Where("catalog_id = ?", id).
+		Where("store_id = ?", storeID).
+		Exec(ctx)
+	_ = cache.DeletePrefix(ctx, r.cache, fmt.Sprintf("catalog:store:%d:", storeID))
 	return err
 }
 
-func (r *Repository) DeleteByName(ctx context.Context, name string) error {
-	_, err := r.db.NewDelete().Model(&catalog{}).Where("name = ?", name).Exec(ctx)
-	_ = cache.DeletePrefix(ctx, r.cache, "catalog:")
+func (r *Repository) DeleteByName(ctx context.Context, name string, storeID int) error {
+	_, err := r.db.NewDelete().Model(&catalog{}).
+		Where("name = ?", name).
+		Where("store_id = ?", storeID).
+		Exec(ctx)
+	_ = cache.DeletePrefix(ctx, r.cache, fmt.Sprintf("catalog:store:%d:", storeID))
 	return err
 }
 
-func (r *Repository) Update(ctx context.Context, id int, input catalogUpdate) (*catalog, error) {
-	catalog := &catalog{}
-	err := r.db.NewSelect().Model(catalog).Where("c.catalog_id = ?", id).Scan(ctx)
+func (r *Repository) Update(ctx context.Context, id int, storeID int, input catalogUpdate) (*catalog, error) {
+	c := &catalog{}
+	err := r.db.NewSelect().Model(c).
+		Where("c.catalog_id = ?", id).
+		Where("c.store_id = ?", storeID).
+		Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if input.Name != nil {
-		catalog.Name = *input.Name
+		c.Name = *input.Name
 	}
 	if input.Description != nil {
-		catalog.Description = *input.Description
+		c.Description = *input.Description
 	}
-	_, err = r.db.NewUpdate().Model(catalog).Where("catalog_id = ?", id).Exec(ctx)
+	_, err = r.db.NewUpdate().Model(c).
+		Where("catalog_id = ?", id).
+		Where("store_id = ?", storeID).
+		Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
-	_ = cache.DeletePrefix(ctx, r.cache, "catalog:")
-	return catalog, nil
+	_ = cache.DeletePrefix(ctx, r.cache, fmt.Sprintf("catalog:store:%d:", storeID))
+	return c, nil
 }

--- a/app/internal/catalog/repository_test.go
+++ b/app/internal/catalog/repository_test.go
@@ -25,14 +25,14 @@ func TestRepository_FindByID(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"name", "description"}).
-		AddRow("Winter 2026 Collection", "All items available for the winter 2026 season")
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).
+		AddRow("Winter 2026 Collection", "All items available for the winter 2026 season", 1)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "c"."name", "c"."description" FROM "catalog" AS "c" WHERE (c.catalog_id = 1)`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "c"."name", "c"."description", "c"."store_id" FROM "catalog" AS "c" WHERE (c.catalog_id = 1) AND (c.store_id = 1)`)).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	c, err := repo.FindByID(ctx, 1)
+	c, err := repo.FindByID(ctx, 1, 1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
@@ -50,6 +50,7 @@ func TestRepository_Create(t *testing.T) {
 	c := &catalog{
 		Name:        "Summer 2026",
 		Description: "Summer clothes",
+		StoreID:     1,
 	}
 
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "catalog"`)).
@@ -68,15 +69,15 @@ func TestRepository_FindAll(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"name", "description"}).
-		AddRow("Cat 1", "Desc 1").
-		AddRow("Cat 2", "Desc 2")
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).
+		AddRow("Cat 1", "Desc 1", 1).
+		AddRow("Cat 2", "Desc 2", 1)
 
-	mock.ExpectQuery(`^SELECT "c"."name", "c"."description" FROM "catalog" AS "c"$`).
+	mock.ExpectQuery(`^SELECT "c"\."name", "c"\."description", "c"\."store_id" FROM "catalog" AS "c" WHERE \(c\.store_id = .+\)$`).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	catalogs, err := repo.FindAll(ctx)
+	catalogs, err := repo.FindAll(ctx, 1)
 
 	assert.NoError(t, err)
 	assert.Len(t, catalogs, 2)
@@ -90,14 +91,14 @@ func TestRepository_FindByName(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"name", "description"}).
-		AddRow("Test Cat", "Test Desc")
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).
+		AddRow("Test Cat", "Test Desc", 1)
 
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c.name = \?|'Test Cat'\)`).
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.name = .+\) AND \(c\.store_id = .+\)$`).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	c, err := repo.FindByName(ctx, "Test Cat")
+	c, err := repo.FindByName(ctx, "Test Cat", 1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
@@ -111,11 +112,11 @@ func TestRepository_DeleteByID(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	mock.ExpectExec(`^DELETE FROM "catalog" AS "c" WHERE \(catalog_id = 1\)$`).
+	mock.ExpectExec(`^DELETE FROM "catalog" AS "c" WHERE \(catalog_id = .+\) AND \(store_id = .+\)$`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	ctx := context.Background()
-	err := repo.DeleteByID(ctx, 1)
+	err := repo.DeleteByID(ctx, 1, 1)
 
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -127,11 +128,11 @@ func TestRepository_DeleteByName(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	mock.ExpectExec(`^DELETE FROM "catalog" AS "c" WHERE \(name = '.+'|\?\)$`).
+	mock.ExpectExec(`^DELETE FROM "catalog" AS "c" WHERE \(name = .+\) AND \(store_id = .+\)$`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	ctx := context.Background()
-	err := repo.DeleteByName(ctx, "Test Cat")
+	err := repo.DeleteByName(ctx, "Test Cat", 1)
 
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -144,9 +145,9 @@ func TestRepository_Update(t *testing.T) {
 	repo := &Repository{db: bunDB}
 
 	// Mock FindByID inside Update
-	rows := sqlmock.NewRows([]string{"name", "description"}).
-		AddRow("Old Name", "Old Desc")
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = \?|1\)$`).
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).
+		AddRow("Old Name", "Old Desc", 1)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\) AND \(c\.store_id = .+\)$`).
 		WillReturnRows(rows)
 
 	// Mock Update
@@ -156,7 +157,7 @@ func TestRepository_Update(t *testing.T) {
 	newName := "New Name"
 	input := catalogUpdate{Name: &newName}
 	ctx := context.Background()
-	c, err := repo.Update(ctx, 1, input)
+	c, err := repo.Update(ctx, 1, 1, input)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, c)

--- a/app/internal/catalog/service.go
+++ b/app/internal/catalog/service.go
@@ -18,13 +18,16 @@ func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) Create(ctx context.Context, input catalogUpdate) (*catalog, error) {
+func (s *Service) Create(ctx context.Context, storeID int, input catalogUpdate) (*catalog, error) {
 	if input.Name == nil || *input.Name == "" {
 		return nil, errors.New("name is required")
 	}
 	c := &catalog{
-		Name:        *input.Name,
-		Description: *input.Description,
+		Name:    *input.Name,
+		StoreID: storeID,
+	}
+	if input.Description != nil {
+		c.Description = *input.Description
 	}
 	if err := s.repo.Create(ctx, c); err != nil {
 		return nil, err
@@ -32,41 +35,41 @@ func (s *Service) Create(ctx context.Context, input catalogUpdate) (*catalog, er
 	return c, nil
 }
 
-func (s *Service) Update(ctx context.Context, id int, input catalogUpdate) (*catalog, error) {
+func (s *Service) Update(ctx context.Context, id int, storeID int, input catalogUpdate) (*catalog, error) {
 	if (input.Name == nil || *input.Name == "") && (input.Description == nil || *input.Description == "") {
 		return nil, errors.New("at least one field is required")
 	}
-	c, err := s.repo.FindByID(ctx, id)
+	_, err := s.repo.FindByID(ctx, id, storeID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrCatalogNotFound
 		}
 		return nil, err
 	}
-	c, err = s.repo.Update(ctx, id, input)
+	c, err := s.repo.Update(ctx, id, storeID, input)
 	if err != nil {
 		return nil, err
 	}
 	return c, nil
 }
 
-func (s *Service) Delete(ctx context.Context, id int) error {
-	_, err := s.repo.FindByID(ctx, id)
+func (s *Service) Delete(ctx context.Context, id int, storeID int) error {
+	_, err := s.repo.FindByID(ctx, id, storeID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrCatalogNotFound
 		}
 		return err
 	}
-	return s.repo.DeleteByID(ctx, id)
+	return s.repo.DeleteByID(ctx, id, storeID)
 }
 
-func (s *Service) GetAll(ctx context.Context) ([]catalog, error) {
-	return s.repo.FindAll(ctx)
+func (s *Service) GetAll(ctx context.Context, storeID int) ([]catalog, error) {
+	return s.repo.FindAll(ctx, storeID)
 }
 
-func (s *Service) GetByID(ctx context.Context, id int) (*catalog, error) {
-	c, err := s.repo.FindByID(ctx, id)
+func (s *Service) GetByID(ctx context.Context, id int, storeID int) (*catalog, error) {
+	c, err := s.repo.FindByID(ctx, id, storeID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrCatalogNotFound

--- a/app/internal/catalog/service_test.go
+++ b/app/internal/catalog/service_test.go
@@ -19,7 +19,7 @@ func TestService_Create_ValidationError(t *testing.T) {
 	svc := NewService(repo)
 
 	desc := "desc"
-	_, err := svc.Create(context.Background(), catalogUpdate{Description: &desc})
+	_, err := svc.Create(context.Background(), 1, catalogUpdate{Description: &desc})
 
 	assert.EqualError(t, err, "name is required")
 }
@@ -31,7 +31,7 @@ func TestService_Update_ValidationError(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	_, err := svc.Update(context.Background(), 1, catalogUpdate{})
+	_, err := svc.Update(context.Background(), 1, 1, catalogUpdate{})
 
 	assert.EqualError(t, err, "at least one field is required")
 }
@@ -43,9 +43,9 @@ func TestService_GetByID_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\) AND \(c\.store_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	_, err := svc.GetByID(context.Background(), 123)
+	_, err := svc.GetByID(context.Background(), 123, 1)
 
 	assert.ErrorIs(t, err, ErrCatalogNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -58,11 +58,11 @@ func TestService_GetAll_Success(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	rows := sqlmock.NewRows([]string{"name", "description"}).
-		AddRow("Cat 1", "Desc 1")
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c"$`).WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"name", "description", "store_id"}).
+		AddRow("Cat 1", "Desc 1", 1)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.store_id = .+\)$`).WillReturnRows(rows)
 
-	list, err := svc.GetAll(context.Background())
+	list, err := svc.GetAll(context.Background(), 1)
 
 	assert.NoError(t, err)
 	assert.Len(t, list, 1)
@@ -77,9 +77,9 @@ func TestService_Delete_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "catalog" AS "c" WHERE \(c\.catalog_id = .+\) AND \(c\.store_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	err := svc.Delete(context.Background(), 10)
+	err := svc.Delete(context.Background(), 10, 1)
 
 	assert.ErrorIs(t, err, ErrCatalogNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/app/internal/categorie/handler.go
+++ b/app/internal/categorie/handler.go
@@ -20,48 +20,62 @@ func NewHandler(service *Service) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(router *gin.Engine) {
-	categorieRoutes := router.Group("/categorie")
+	categorieRoutes := router.Group("/catalog/:catalog_id/categorie")
 	{
 		protected := categorieRoutes.Group("")
 		protected.Use(middleware.ProfileAuthMiddleware())
 		{
-			protected.GET("", h.GetAll)               // GET /categorie
-			protected.GET("/type/:type", h.GetByType) // GET /categorie/type/:type — must be before /:id
-			protected.GET("/:id", h.GetByID)          // GET /categorie/:id
+			protected.GET("", h.GetAll)               // GET /catalog/:catalog_id/categorie
+			protected.GET("/type/:type", h.GetByType) // GET /catalog/:catalog_id/categorie/type/:type
+			protected.GET("/:id", h.GetByID)          // GET /catalog/:catalog_id/categorie/:id
 
 			managerRoutes := protected.Group("")
 			managerRoutes.Use(middleware.LevelAccessRequired(token.Manager))
 			{
-				managerRoutes.POST("", h.Create)                    // POST /categorie
-				managerRoutes.PUT("/:id", h.Update)                 // PUT /categorie/:id
-				managerRoutes.DELETE("/type/:type", h.DeleteByType) // DELETE /categorie/type/:type — must be before /:id
-				managerRoutes.DELETE("/:id", h.DeleteByID)          // DELETE /categorie/:id
+				managerRoutes.POST("", h.Create)                    // POST /catalog/:catalog_id/categorie
+				managerRoutes.PUT("/:id", h.Update)                 // PUT /catalog/:catalog_id/categorie/:id
+				managerRoutes.DELETE("/type/:type", h.DeleteByType) // DELETE /catalog/:catalog_id/categorie/type/:type
+				managerRoutes.DELETE("/:id", h.DeleteByID)          // DELETE /catalog/:catalog_id/categorie/:id
 			}
 		}
 	}
 }
 
+func parseCatalogID(c *gin.Context) (int, bool) {
+	catalogID, err := strconv.Atoi(c.Param("catalog_id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid catalog_id"})
+		return 0, false
+	}
+	return catalogID, true
+}
+
 // Create adds a new categorie
 // @Summary      Create a categorie
-// @Description  Creates a new categorie in the system. Requires Manager level access.
+// @Description  Creates a new categorie in a catalog. Requires Manager level access.
 // @Tags         categorie
 // @Accept       json
 // @Produce      json
 // @Security     ProfileToken
-// @Param        body body      Categorie true "Categorie payload"
+// @Param        catalog_id path      int       true "Catalog ID"    example(1)
+// @Param        body       body      Categorie true "Categorie payload"
 // @Success      201  {object}  Categorie
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /categorie [post]
+// @Router       /catalog/{catalog_id}/categorie [post]
 func (h *Handler) Create(c *gin.Context) {
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
 	var input Categorie
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	categorie, err := h.service.Create(c.Request.Context(), input)
+	categorie, err := h.service.Create(c.Request.Context(), catalogID, input)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -69,18 +83,24 @@ func (h *Handler) Create(c *gin.Context) {
 	c.JSON(http.StatusCreated, categorie)
 }
 
-// GetAll retrieves the list of all categories
+// GetAll retrieves all categories for a catalog
 // @Summary      List categories
-// @Description  Retrieves the complete list of categories
+// @Description  Retrieves all categories belonging to a catalog
 // @Tags         categorie
 // @Produce      json
 // @Security     ProfileToken
+// @Param        catalog_id path      int  true "Catalog ID"  example(1)
 // @Success      200  {array}   Categorie
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /categorie [get]
+// @Router       /catalog/{catalog_id}/categorie [get]
 func (h *Handler) GetAll(c *gin.Context) {
-	categories, err := h.service.FindAll(c.Request.Context())
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
+	categories, err := h.service.FindAll(c.Request.Context(), catalogID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -88,26 +108,30 @@ func (h *Handler) GetAll(c *gin.Context) {
 	c.JSON(http.StatusOK, categories)
 }
 
-// GetByID retrieves a categorie by its ID
+// GetByID retrieves a categorie by its ID within a catalog
 // @Summary      Retrieve a categorie
-// @Description  Retrieves the details of a categorie using its ID
+// @Description  Retrieves the details of a categorie using its ID within a catalog
 // @Tags         categorie
 // @Produce      json
 // @Security     ProfileToken
-// @Param        id   path      int  true  "Categorie ID"  example(1)
+// @Param        catalog_id path      int  true "Catalog ID"    example(1)
+// @Param        id         path      int  true "Categorie ID"  example(1)
 // @Success      200  {object}  Categorie
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
-// @Router       /categorie/{id} [get]
+// @Router       /catalog/{catalog_id}/categorie/{id} [get]
 func (h *Handler) GetByID(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	categorie, err := h.service.FindByID(c.Request.Context(), id)
+	categorie, err := h.service.FindByID(c.Request.Context(), id, catalogID)
 	if err != nil {
 		if errors.Is(err, ErrCategorieNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "categorie not found"})
@@ -119,20 +143,26 @@ func (h *Handler) GetByID(c *gin.Context) {
 	c.JSON(http.StatusOK, categorie)
 }
 
-// GetByType retrieves a categorie by its type
+// GetByType retrieves a categorie by its type within a catalog
 // @Summary      Retrieve a categorie by type
-// @Description  Retrieves the details of a categorie using its type
+// @Description  Retrieves the details of a categorie using its type within a catalog
 // @Tags         categorie
 // @Produce      json
 // @Security     ProfileToken
-// @Param        type path      string  true  "Categorie type"  example(Electronics)
+// @Param        catalog_id path      int    true "Catalog ID"       example(1)
+// @Param        type       path      string true "Categorie type"   example(Electronics)
 // @Success      200  {object}  Categorie
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
-// @Router       /categorie/type/{type} [get]
+// @Router       /catalog/{catalog_id}/categorie/type/{type} [get]
 func (h *Handler) GetByType(c *gin.Context) {
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
 	typ := c.Param("type")
-	categorie, err := h.service.FindByType(c.Request.Context(), typ)
+	categorie, err := h.service.FindByType(c.Request.Context(), typ, catalogID)
 	if err != nil {
 		if errors.Is(err, ErrCategorieNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "categorie not found"})
@@ -144,25 +174,29 @@ func (h *Handler) GetByType(c *gin.Context) {
 	c.JSON(http.StatusOK, categorie)
 }
 
-// Update modifies an existing categorie
+// Update modifies an existing categorie within a catalog
 // @Summary      Update a categorie
-// @Description  Modifies the information of an existing categorie via its ID. Requires Manager level access.
+// @Description  Modifies the information of an existing categorie. Requires Manager level access.
 // @Tags         categorie
 // @Accept       json
 // @Produce      json
-// @Param        id   path      int       true "Categorie ID"  example(1)
-// @Param        body body      Categorie true "Categorie update payload"
+// @Security     ProfileToken
+// @Param        catalog_id path      int       true "Catalog ID"    example(1)
+// @Param        id         path      int       true "Categorie ID"  example(1)
+// @Param        body       body      Categorie true "Categorie update payload"
 // @Success      200  {object}  Categorie
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Security     ProfileToken
-// @Router       /categorie/{id} [put]
+// @Router       /catalog/{catalog_id}/categorie/{id} [put]
 func (h *Handler) Update(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
@@ -172,7 +206,7 @@ func (h *Handler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	categorie, err := h.service.Update(c.Request.Context(), id, input)
+	categorie, err := h.service.Update(c.Request.Context(), id, catalogID, input)
 	if err != nil {
 		if errors.Is(err, ErrCategorieNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "categorie not found"})
@@ -184,28 +218,32 @@ func (h *Handler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, categorie)
 }
 
-// DeleteByID removes a categorie by its ID
+// DeleteByID removes a categorie by its ID within a catalog
 // @Summary      Delete a categorie
-// @Description  Deletes a categorie from the system via its ID. Requires Manager level access.
+// @Description  Deletes a categorie from a catalog via its ID. Requires Manager level access.
 // @Tags         categorie
 // @Produce      json
-// @Param        id   path      int  true  "Categorie ID"  example(1)
+// @Security     ProfileToken
+// @Param        catalog_id path      int  true "Catalog ID"    example(1)
+// @Param        id         path      int  true "Categorie ID"  example(1)
 // @Success      204  {object}  nil
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Security     ProfileToken
-// @Router       /categorie/{id} [delete]
+// @Router       /catalog/{catalog_id}/categorie/{id} [delete]
 func (h *Handler) DeleteByID(c *gin.Context) {
-	idStr := c.Param("id")
-	id, err := strconv.Atoi(idStr)
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
+	id, err := strconv.Atoi(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
 		return
 	}
-	err = h.service.DeleteByID(c.Request.Context(), id)
+	err = h.service.DeleteByID(c.Request.Context(), id, catalogID)
 	if err != nil {
 		if errors.Is(err, ErrCategorieNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "categorie not found"})
@@ -217,22 +255,28 @@ func (h *Handler) DeleteByID(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// DeleteByType removes categories by their type
+// DeleteByType removes categories by their type within a catalog
 // @Summary      Delete a categorie by type
-// @Description  Deletes a categorie from the system via its type. Requires Manager level access.
+// @Description  Deletes a categorie from a catalog via its type. Requires Manager level access.
 // @Tags         categorie
 // @Produce      json
-// @Param        type path      string  true  "Categorie type"  example(Electronics)
+// @Security     ProfileToken
+// @Param        catalog_id path      int    true "Catalog ID"      example(1)
+// @Param        type       path      string true "Categorie type"  example(Electronics)
 // @Success      204  {object}  nil
+// @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Security     ProfileToken
-// @Router       /categorie/type/{type} [delete]
+// @Router       /catalog/{catalog_id}/categorie/type/{type} [delete]
 func (h *Handler) DeleteByType(c *gin.Context) {
+	catalogID, ok := parseCatalogID(c)
+	if !ok {
+		return
+	}
 	typ := c.Param("type")
-	err := h.service.DeleteByType(c.Request.Context(), typ)
+	err := h.service.DeleteByType(c.Request.Context(), typ, catalogID)
 	if err != nil {
 		if errors.Is(err, ErrCategorieNotFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "categorie not found"})

--- a/app/internal/categorie/handler.go
+++ b/app/internal/categorie/handler.go
@@ -20,22 +20,22 @@ func NewHandler(service *Service) *Handler {
 }
 
 func (h *Handler) RegisterRoutes(router *gin.Engine) {
-	categorieRoutes := router.Group("/catalog/:catalog_id/categorie")
+	categorieRoutes := router.Group("/categorie/catalog/:catalog_id")
 	{
 		protected := categorieRoutes.Group("")
 		protected.Use(middleware.ProfileAuthMiddleware())
 		{
-			protected.GET("", h.GetAll)               // GET /catalog/:catalog_id/categorie
-			protected.GET("/type/:type", h.GetByType) // GET /catalog/:catalog_id/categorie/type/:type
-			protected.GET("/:id", h.GetByID)          // GET /catalog/:catalog_id/categorie/:id
+			protected.GET("", h.GetAll)               // GET /categorie/catalog/:catalog_id
+			protected.GET("/type/:type", h.GetByType) // GET /categorie/catalog/:catalog_id/type/:type
+			protected.GET("/:id", h.GetByID)          // GET /categorie/catalog/:catalog_id/:id
 
 			managerRoutes := protected.Group("")
 			managerRoutes.Use(middleware.LevelAccessRequired(token.Manager))
 			{
-				managerRoutes.POST("", h.Create)                    // POST /catalog/:catalog_id/categorie
-				managerRoutes.PUT("/:id", h.Update)                 // PUT /catalog/:catalog_id/categorie/:id
-				managerRoutes.DELETE("/type/:type", h.DeleteByType) // DELETE /catalog/:catalog_id/categorie/type/:type
-				managerRoutes.DELETE("/:id", h.DeleteByID)          // DELETE /catalog/:catalog_id/categorie/:id
+				managerRoutes.POST("", h.Create)                    // POST /categorie/catalog/:catalog_id
+				managerRoutes.PUT("/:id", h.Update)                 // PUT /categorie/catalog/:catalog_id/:id
+				managerRoutes.DELETE("/type/:type", h.DeleteByType) // DELETE /categorie/catalog/:catalog_id/type/:type
+				managerRoutes.DELETE("/:id", h.DeleteByID)          // DELETE /categorie/catalog/:catalog_id/:id
 			}
 		}
 	}
@@ -64,7 +64,7 @@ func parseCatalogID(c *gin.Context) (int, bool) {
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie [post]
+// @Router       /categorie/catalog/{catalog_id} [post]
 func (h *Handler) Create(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -94,7 +94,7 @@ func (h *Handler) Create(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie [get]
+// @Router       /categorie/catalog/{catalog_id} [get]
 func (h *Handler) GetAll(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -120,7 +120,7 @@ func (h *Handler) GetAll(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie/{id} [get]
+// @Router       /categorie/catalog/{catalog_id}/{id} [get]
 func (h *Handler) GetByID(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -155,7 +155,7 @@ func (h *Handler) GetByID(c *gin.Context) {
 // @Failure      400  {object}  map[string]interface{}
 // @Failure      401  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie/type/{type} [get]
+// @Router       /categorie/catalog/{catalog_id}/type/{type} [get]
 func (h *Handler) GetByType(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -190,7 +190,7 @@ func (h *Handler) GetByType(c *gin.Context) {
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie/{id} [put]
+// @Router       /categorie/catalog/{catalog_id}/{id} [put]
 func (h *Handler) Update(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -232,7 +232,7 @@ func (h *Handler) Update(c *gin.Context) {
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie/{id} [delete]
+// @Router       /categorie/catalog/{catalog_id}/{id} [delete]
 func (h *Handler) DeleteByID(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {
@@ -269,7 +269,7 @@ func (h *Handler) DeleteByID(c *gin.Context) {
 // @Failure      403  {object}  map[string]interface{}
 // @Failure      404  {object}  map[string]interface{}
 // @Failure      500  {object}  map[string]interface{}
-// @Router       /catalog/{catalog_id}/categorie/type/{type} [delete]
+// @Router       /categorie/catalog/{catalog_id}/type/{type} [delete]
 func (h *Handler) DeleteByType(c *gin.Context) {
 	catalogID, ok := parseCatalogID(c)
 	if !ok {

--- a/app/internal/categorie/handler_test.go
+++ b/app/internal/categorie/handler_test.go
@@ -37,9 +37,9 @@ func TestHandler_Create_BadJSON(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCategorieHandler(t)
-	r.POST("/categorie", h.Create)
+	r.POST("/catalog/:catalog_id/categorie", h.Create)
 
-	req := httptest.NewRequest(http.MethodPost, "/categorie", bytes.NewBufferString("{"))
+	req := httptest.NewRequest(http.MethodPost, "/catalog/1/categorie", bytes.NewBufferString("{"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -52,9 +52,9 @@ func TestHandler_GetByID_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCategorieHandler(t)
-	r.GET("/categorie/:id", h.GetByID)
+	r.GET("/catalog/:catalog_id/categorie/:id", h.GetByID)
 
-	req := httptest.NewRequest(http.MethodGet, "/categorie/abc", nil)
+	req := httptest.NewRequest(http.MethodGet, "/catalog/1/categorie/abc", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -66,9 +66,9 @@ func TestHandler_Update_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCategorieHandler(t)
-	r.PUT("/categorie/:id", h.Update)
+	r.PUT("/catalog/:catalog_id/categorie/:id", h.Update)
 
-	req := httptest.NewRequest(http.MethodPut, "/categorie/abc", bytes.NewBufferString("{}"))
+	req := httptest.NewRequest(http.MethodPut, "/catalog/1/categorie/abc", bytes.NewBufferString("{}"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 
@@ -81,9 +81,9 @@ func TestHandler_DeleteByID_InvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, _ := setupCategorieHandler(t)
-	r.DELETE("/categorie/:id", h.DeleteByID)
+	r.DELETE("/catalog/:catalog_id/categorie/:id", h.DeleteByID)
 
-	req := httptest.NewRequest(http.MethodDelete, "/categorie/abc", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/catalog/1/categorie/abc", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)

--- a/app/internal/categorie/handler_test.go
+++ b/app/internal/categorie/handler_test.go
@@ -95,11 +95,11 @@ func TestHandler_GetByType_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, mock := setupCategorieHandler(t)
-	r.GET("/categorie/type/:type", h.GetByType)
+	r.GET("/catalog/:catalog_id/categorie/type/:type", h.GetByType)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	req := httptest.NewRequest(http.MethodGet, "/categorie/type/missing", nil)
+	req := httptest.NewRequest(http.MethodGet, "/catalog/1/categorie/type/missing", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -112,11 +112,11 @@ func TestHandler_DeleteByType_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, mock := setupCategorieHandler(t)
-	r.DELETE("/categorie/type/:type", h.DeleteByType)
+	r.DELETE("/catalog/:catalog_id/categorie/type/:type", h.DeleteByType)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	req := httptest.NewRequest(http.MethodDelete, "/categorie/type/missing", nil)
+	req := httptest.NewRequest(http.MethodDelete, "/catalog/1/categorie/type/missing", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)
@@ -129,12 +129,12 @@ func TestHandler_GetAll_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	h, mock := setupCategorieHandler(t)
-	r.GET("/categorie", h.GetAll)
+	r.GET("/catalog/:catalog_id/categorie", h.GetAll)
 
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).AddRow(1, "Books")
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat"$`).WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).AddRow(1, "Books", 1)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.catalog_id = .+\)$`).WillReturnRows(rows)
 
-	req := httptest.NewRequest(http.MethodGet, "/categorie", nil)
+	req := httptest.NewRequest(http.MethodGet, "/catalog/1/categorie", nil)
 	w := httptest.NewRecorder()
 
 	r.ServeHTTP(w, req)

--- a/app/internal/categorie/model.go
+++ b/app/internal/categorie/model.go
@@ -7,4 +7,5 @@ type Categorie struct {
 
 	CategorieID int    `bun:"categorie_id,pk,autoincrement" json:"categorie_id" example:"1"`
 	Type        string `bun:"type"                          json:"type"         example:"Electronics"`
+	CatalogID   int    `bun:"catalog_id,notnull"            json:"catalog_id"   example:"1"`
 }

--- a/app/internal/categorie/repository.go
+++ b/app/internal/categorie/repository.go
@@ -21,54 +21,78 @@ func (r *Repository) Create(ctx context.Context, c *Categorie) error {
 	return err
 }
 
-func (r *Repository) FindAll(ctx context.Context) ([]Categorie, error) {
+func (r *Repository) FindAll(ctx context.Context, catalogID int) ([]Categorie, error) {
 	var categories []Categorie
-	err := r.db.NewSelect().Model(&categories).Scan(ctx)
+	err := r.db.NewSelect().Model(&categories).Where("cat.catalog_id = ?", catalogID).Scan(ctx)
 	return categories, err
 }
 
-func (r *Repository) FindByID(ctx context.Context, id int) (*Categorie, error) {
+func (r *Repository) FindByID(ctx context.Context, id int, catalogID int) (*Categorie, error) {
 	c := new(Categorie)
-	err := r.db.NewSelect().Model(c).Where("cat.categorie_id = ?", id).Scan(ctx)
+	err := r.db.NewSelect().Model(c).
+		Where("cat.categorie_id = ?", id).
+		Where("cat.catalog_id = ?", catalogID).
+		Scan(ctx)
 	return c, err
 }
 
-func (r *Repository) FindByType(ctx context.Context, typ string) (*Categorie, error) {
+func (r *Repository) FindByType(ctx context.Context, typ string, catalogID int) (*Categorie, error) {
 	c := new(Categorie)
-	err := r.db.NewSelect().Model(c).Where("cat.type = ?", typ).Scan(ctx)
+	err := r.db.NewSelect().Model(c).
+		Where("cat.type = ?", typ).
+		Where("cat.catalog_id = ?", catalogID).
+		Scan(ctx)
 	return c, err
 }
 
-func (r *Repository) Update(ctx context.Context, id int, c *Categorie) (*Categorie, error) {
+func (r *Repository) Update(ctx context.Context, id int, catalogID int, c *Categorie) (*Categorie, error) {
 	cat := &Categorie{}
-	err := r.db.NewSelect().Model(cat).Where("cat.categorie_id = ?", id).Scan(ctx)
+	err := r.db.NewSelect().Model(cat).
+		Where("cat.categorie_id = ?", id).
+		Where("cat.catalog_id = ?", catalogID).
+		Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
 	cat.Type = c.Type
-	_, err = r.db.NewUpdate().Model(cat).Where("cat.categorie_id = ?", id).Exec(ctx)
+	_, err = r.db.NewUpdate().Model(cat).
+		Where("cat.categorie_id = ?", id).
+		Where("cat.catalog_id = ?", catalogID).
+		Exec(ctx)
 	if err != nil {
 		return nil, err
 	}
 	return cat, nil
 }
 
-func (r *Repository) DeleteById(ctx context.Context, id int) error {
+func (r *Repository) DeleteById(ctx context.Context, id int, catalogID int) error {
 	cat := &Categorie{}
-	err := r.db.NewSelect().Model(cat).Where("cat.categorie_id = ?", id).Scan(ctx)
+	err := r.db.NewSelect().Model(cat).
+		Where("cat.categorie_id = ?", id).
+		Where("cat.catalog_id = ?", catalogID).
+		Scan(ctx)
 	if err != nil {
 		return err
 	}
-	_, er := r.db.NewDelete().Model(cat).Where("cat.categorie_id = ?", id).Exec(ctx)
+	_, er := r.db.NewDelete().Model(cat).
+		Where("cat.categorie_id = ?", id).
+		Where("cat.catalog_id = ?", catalogID).
+		Exec(ctx)
 	return er
 }
 
-func (r *Repository) DeleteByType(ctx context.Context, typ string) error {
+func (r *Repository) DeleteByType(ctx context.Context, typ string, catalogID int) error {
 	cat := &Categorie{}
-	err := r.db.NewSelect().Model(cat).Where("cat.type = ?", typ).Scan(ctx)
+	err := r.db.NewSelect().Model(cat).
+		Where("cat.type = ?", typ).
+		Where("cat.catalog_id = ?", catalogID).
+		Scan(ctx)
 	if err != nil {
 		return err
 	}
-	_, er := r.db.NewDelete().Model(cat).Where("cat.type = ?", typ).Exec(ctx)
+	_, er := r.db.NewDelete().Model(cat).
+		Where("cat.type = ?", typ).
+		Where("cat.catalog_id = ?", catalogID).
+		Exec(ctx)
 	return er
 }

--- a/app/internal/categorie/repository_test.go
+++ b/app/internal/categorie/repository_test.go
@@ -25,14 +25,14 @@ func TestRepository_FindByID(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).
-		AddRow(1, "Electronics")
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).
+		AddRow(1, "Electronics", 1)
 
-	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "cat"."categorie_id", "cat"."type" FROM "categorie" AS "cat" WHERE (cat.categorie_id = 1)`)).
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT "cat"."categorie_id", "cat"."type", "cat"."catalog_id" FROM "categorie" AS "cat" WHERE (cat.categorie_id = 1) AND (cat.catalog_id = 1)`)).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	cat, err := repo.FindByID(ctx, 1)
+	cat, err := repo.FindByID(ctx, 1, 1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, cat)
@@ -48,7 +48,8 @@ func TestRepository_Create(t *testing.T) {
 	repo := &Repository{db: bunDB}
 
 	cat := &Categorie{
-		Type: "Books",
+		Type:      "Books",
+		CatalogID: 1,
 	}
 
 	mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "categorie"`)).
@@ -66,15 +67,15 @@ func TestRepository_FindAll(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).
-		AddRow(1, "Electronics").
-		AddRow(2, "Books")
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).
+		AddRow(1, "Electronics", 1).
+		AddRow(2, "Books", 1)
 
-	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type" FROM "categorie" AS "cat"$`).
+	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type", "cat"\."catalog_id" FROM "categorie" AS "cat" WHERE \(cat\.catalog_id = .+\)$`).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	categories, err := repo.FindAll(ctx)
+	categories, err := repo.FindAll(ctx, 1)
 
 	assert.NoError(t, err)
 	assert.Len(t, categories, 2)
@@ -88,14 +89,14 @@ func TestRepository_FindByType(t *testing.T) {
 
 	repo := &Repository{db: bunDB}
 
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).
-		AddRow(1, "Electronics")
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).
+		AddRow(1, "Electronics", 1)
 
-	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type" FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).
+	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type", "cat"\."catalog_id" FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnRows(rows)
 
 	ctx := context.Background()
-	c, err := repo.FindByType(ctx, "Electronics")
+	c, err := repo.FindByType(ctx, "Electronics", 1)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
@@ -110,8 +111,8 @@ func TestRepository_Update(t *testing.T) {
 	repo := &Repository{db: bunDB}
 
 	// Mock Find
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).AddRow(1, "Old Type")
-	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type" FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).AddRow(1, "Old Type", 1)
+	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type", "cat"\."catalog_id" FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnRows(rows)
 
 	// Mock Update
@@ -120,7 +121,7 @@ func TestRepository_Update(t *testing.T) {
 
 	c := &Categorie{Type: "New Type"}
 	ctx := context.Background()
-	updatedCat, err := repo.Update(ctx, 1, c)
+	updatedCat, err := repo.Update(ctx, 1, 1, c)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, updatedCat)
@@ -135,16 +136,16 @@ func TestRepository_DeleteById(t *testing.T) {
 	repo := &Repository{db: bunDB}
 
 	// Mock Find
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).AddRow(1, "Electronics")
-	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type" FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).AddRow(1, "Electronics", 1)
+	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type", "cat"\."catalog_id" FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnRows(rows)
 
 	// Mock Delete
-	mock.ExpectExec(`^DELETE FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).
+	mock.ExpectExec(`^DELETE FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	ctx := context.Background()
-	err := repo.DeleteById(ctx, 1)
+	err := repo.DeleteById(ctx, 1, 1)
 
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -157,16 +158,16 @@ func TestRepository_DeleteByType(t *testing.T) {
 	repo := &Repository{db: bunDB}
 
 	// Mock Find
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).AddRow(1, "Electronics")
-	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type" FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).AddRow(1, "Electronics", 1)
+	mock.ExpectQuery(`^SELECT "cat"\."categorie_id", "cat"\."type", "cat"\."catalog_id" FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnRows(rows)
 
 	// Mock Delete
-	mock.ExpectExec(`^DELETE FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).
+	mock.ExpectExec(`^DELETE FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	ctx := context.Background()
-	err := repo.DeleteByType(ctx, "Electronics")
+	err := repo.DeleteByType(ctx, "Electronics", 1)
 
 	assert.NoError(t, err)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/app/internal/categorie/service.go
+++ b/app/internal/categorie/service.go
@@ -18,12 +18,13 @@ func NewService(repo *Repository) *Service {
 	return &Service{repo: repo}
 }
 
-func (s *Service) Create(ctx context.Context, input Categorie) (*Categorie, error) {
+func (s *Service) Create(ctx context.Context, catalogID int, input Categorie) (*Categorie, error) {
 	if input.Type == "" {
 		return nil, errors.New("type is required")
 	}
 	c := &Categorie{
-		Type: input.Type,
+		Type:      input.Type,
+		CatalogID: catalogID,
 	}
 	if err := s.repo.Create(ctx, c); err != nil {
 		return nil, err
@@ -31,8 +32,8 @@ func (s *Service) Create(ctx context.Context, input Categorie) (*Categorie, erro
 	return c, nil
 }
 
-func (s *Service) Update(ctx context.Context, id int, input Categorie) (*Categorie, error) {
-	c, err := s.repo.Update(ctx, id, &input)
+func (s *Service) Update(ctx context.Context, id int, catalogID int, input Categorie) (*Categorie, error) {
+	c, err := s.repo.Update(ctx, id, catalogID, &input)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrCategorieNotFound
@@ -42,8 +43,8 @@ func (s *Service) Update(ctx context.Context, id int, input Categorie) (*Categor
 	return c, nil
 }
 
-func (s *Service) DeleteByID(ctx context.Context, id int) error {
-	if err := s.repo.DeleteById(ctx, id); err != nil {
+func (s *Service) DeleteByID(ctx context.Context, id int, catalogID int) error {
+	if err := s.repo.DeleteById(ctx, id, catalogID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrCategorieNotFound
 		}
@@ -52,8 +53,8 @@ func (s *Service) DeleteByID(ctx context.Context, id int) error {
 	return nil
 }
 
-func (s *Service) DeleteByType(ctx context.Context, typ string) error {
-	if err := s.repo.DeleteByType(ctx, typ); err != nil {
+func (s *Service) DeleteByType(ctx context.Context, typ string, catalogID int) error {
+	if err := s.repo.DeleteByType(ctx, typ, catalogID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrCategorieNotFound
 		}
@@ -62,8 +63,8 @@ func (s *Service) DeleteByType(ctx context.Context, typ string) error {
 	return nil
 }
 
-func (s *Service) FindByID(ctx context.Context, id int) (*Categorie, error) {
-	c, err := s.repo.FindByID(ctx, id)
+func (s *Service) FindByID(ctx context.Context, id int, catalogID int) (*Categorie, error) {
+	c, err := s.repo.FindByID(ctx, id, catalogID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrCategorieNotFound
@@ -73,8 +74,8 @@ func (s *Service) FindByID(ctx context.Context, id int) (*Categorie, error) {
 	return c, nil
 }
 
-func (s *Service) FindByType(ctx context.Context, typ string) (*Categorie, error) {
-	c, err := s.repo.FindByType(ctx, typ)
+func (s *Service) FindByType(ctx context.Context, typ string, catalogID int) (*Categorie, error) {
+	c, err := s.repo.FindByType(ctx, typ, catalogID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrCategorieNotFound
@@ -84,6 +85,6 @@ func (s *Service) FindByType(ctx context.Context, typ string) (*Categorie, error
 	return c, nil
 }
 
-func (s *Service) FindAll(ctx context.Context) ([]Categorie, error) {
-	return s.repo.FindAll(ctx)
+func (s *Service) FindAll(ctx context.Context, catalogID int) ([]Categorie, error) {
+	return s.repo.FindAll(ctx, catalogID)
 }

--- a/app/internal/categorie/service_test.go
+++ b/app/internal/categorie/service_test.go
@@ -18,7 +18,7 @@ func TestService_Create_ValidationError(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	_, err := svc.Create(context.Background(), Categorie{})
+	_, err := svc.Create(context.Background(), 1, Categorie{})
 
 	assert.EqualError(t, err, "type is required")
 }
@@ -30,9 +30,9 @@ func TestService_FindByID_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	_, err := svc.FindByID(context.Background(), 1)
+	_, err := svc.FindByID(context.Background(), 1, 1)
 
 	assert.ErrorIs(t, err, ErrCategorieNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -45,9 +45,9 @@ func TestService_DeleteByID_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	err := svc.DeleteByID(context.Background(), 1)
+	err := svc.DeleteByID(context.Background(), 1, 1)
 
 	assert.ErrorIs(t, err, ErrCategorieNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -60,10 +60,10 @@ func TestService_FindAll_Success(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	rows := sqlmock.NewRows([]string{"categorie_id", "type"}).AddRow(1, "Books")
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat"$`).WillReturnRows(rows)
+	rows := sqlmock.NewRows([]string{"categorie_id", "type", "catalog_id"}).AddRow(1, "Books", 1)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.catalog_id = .+\)$`).WillReturnRows(rows)
 
-	list, err := svc.FindAll(context.Background())
+	list, err := svc.FindAll(context.Background(), 1)
 
 	assert.NoError(t, err)
 	assert.Len(t, list, 1)
@@ -78,9 +78,9 @@ func TestService_Update_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.categorie_id = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	_, err := svc.Update(context.Background(), 1, Categorie{Type: "Books"})
+	_, err := svc.Update(context.Background(), 1, 1, Categorie{Type: "Books"})
 
 	assert.ErrorIs(t, err, ErrCategorieNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -93,9 +93,9 @@ func TestService_FindByType_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	_, err := svc.FindByType(context.Background(), "missing")
+	_, err := svc.FindByType(context.Background(), "missing", 1)
 
 	assert.ErrorIs(t, err, ErrCategorieNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -108,9 +108,9 @@ func TestService_DeleteByType_NotFound(t *testing.T) {
 	repo := NewRepository(&db.Db{DB: bunDB})
 	svc := NewService(repo)
 
-	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\)$`).WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery(`^SELECT .* FROM "categorie" AS "cat" WHERE \(cat\.type = .+\) AND \(cat\.catalog_id = .+\)$`).WillReturnError(sql.ErrNoRows)
 
-	err := svc.DeleteByType(context.Background(), "missing")
+	err := svc.DeleteByType(context.Background(), "missing", 1)
 
 	assert.ErrorIs(t, err, ErrCategorieNotFound)
 	assert.NoError(t, mock.ExpectationsWereMet())

--- a/database/init-db.sh
+++ b/database/init-db.sh
@@ -5,13 +5,13 @@ set -e
 files=(
     "account.sql"
     "licence.sql"
-    "categories.sql"
     "image.sql"
+    "store.sql"
     "catalog.sql"
+    "categories.sql"
     "item.sql"
     "payment.sql"
     "sales.sql"
-    "store.sql"
     "profile.sql"
 )
 

--- a/database/schemas/tables/catalog.sql
+++ b/database/schemas/tables/catalog.sql
@@ -1,5 +1,6 @@
 CREATE TABLE catalog (
     catalog_id SERIAL PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
-    description TEXT
+    description TEXT,
+    store_id INTEGER NOT NULL REFERENCES store(store_id) ON DELETE CASCADE
 );

--- a/database/schemas/tables/categories.sql
+++ b/database/schemas/tables/categories.sql
@@ -1,4 +1,5 @@
 CREATE TABLE categorie (
     categorie_id SERIAL PRIMARY KEY,
-    type VARCHAR(100)
+    type VARCHAR(100),
+    catalog_id INTEGER NOT NULL REFERENCES catalog(catalog_id) ON DELETE CASCADE
 );

--- a/database/schemas/tables/licence.sql
+++ b/database/schemas/tables/licence.sql
@@ -2,6 +2,7 @@ CREATE TABLE licence (
     licence_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     account_id INTEGER NOT NULL REFERENCES account(account_id) ON DELETE CASCADE,
     expiration TIMESTAMP NOT NULL,
+    next_payment TIMESTAMP NOT NULL,
     transaction VARCHAR(255),
     is_active BOOLEAN DEFAULT TRUE
 );


### PR DESCRIPTION
This pull request refactors the catalog API and repository to support multi-store catalog management. Now, all catalog operations are scoped to a specific store, requiring a `store_id` in the API path and throughout the backend logic. The changes ensure that catalogs are always associated with a store and that queries, updates, and deletions are restricted to the correct store context. Tests and documentation are updated accordingly.

Key changes include:

**API and Handler Updates:**

- All catalog endpoints are now nested under `/store/:store_id/catalog`, requiring a `store_id` path parameter for all catalog operations. Handler methods extract and validate `store_id` from the path, and API documentation is updated to reflect the new routes and parameters. [[1]](diffhunk://#diff-63ed423e73541492f9f2a73aad864219e36c1e9eefe378ab243e8523a2191e67L23-R131) [[2]](diffhunk://#diff-63ed423e73541492f9f2a73aad864219e36c1e9eefe378ab243e8523a2191e67L118-R163) [[3]](diffhunk://#diff-63ed423e73541492f9f2a73aad864219e36c1e9eefe378ab243e8523a2191e67L144-R210)

**Repository and Model Changes:**

- The `catalog` model now includes a `StoreID` field to associate each catalog with a store. All repository methods are updated to require and use `store_id` in their queries, ensuring catalogs are only accessible within their store. Cache keys are also updated to be store-specific. [[1]](diffhunk://#diff-f6e9497c0ec90e18bbdf6b2ef6637b4ae58cf35beebc51b72e452b6ddd306539R13) [[2]](diffhunk://#diff-96274a2867ae4f5ffc4f77fe7f6bbd0f49320cf89a7363c9ba61e43c430927d9L29-R107)

**Test Updates:**

- All handler and repository tests are updated to use the new `/store/:store_id/catalog` routes and to expect/store the `store_id` field. SQL queries in tests are modified to include `store_id` conditions. [[1]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L40-R42) [[2]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L55-R57) [[3]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L69-R73) [[4]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L86-R88) [[5]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L101-R103) [[6]](diffhunk://#diff-b889e720d137da7cf00bd545797007c4d43bf6617a5fb63fbc6ebb7e3a6137e3L115-R120) [[7]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL28-R35) [[8]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aR53) [[9]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL71-R80) [[10]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL93-R101) [[11]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL114-R119) [[12]](diffhunk://#diff-5074d8649b2977810c7b6b7596e01bcc6c786ae233c8d14c27127f13c60f598aL130-R135)