### PR TITLE
feat(backend-13): Add a basic logic for kpi calculation

### DIFF
--- a/app/internal/sale/handler.go
+++ b/app/internal/sale/handler.go
@@ -3,6 +3,8 @@ package sale
 import (
 	"errors"
 	"net/http"
+	"strings"
+	"time"
 
 	"tili/app/internal/middleware"
 	"tili/app/internal/token"
@@ -10,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
+
+const dateOnlyLayout = "2006-01-02"
 
 type Handler struct {
 	service *Service
@@ -26,6 +30,7 @@ func (h *Handler) RegisterRoutes(rg *gin.Engine) {
 	{
 		protected.POST("", h.CreateSale)
 		protected.GET("", h.GetAllSales)
+		protected.GET("/kpi", h.GetSalesKPI)
 		protected.GET("/:id", h.GetSaleByID)
 		managerRoutes := protected.Group("")
 		managerRoutes.Use(middleware.LevelAccessRequired(token.Manager))
@@ -116,6 +121,52 @@ func (h *Handler) GetSaleByID(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, sale)
+}
+
+// @Summary      Sales KPI report
+// @Description  Returns revenue KPIs bucketed by day, week, or month: total revenue, revenue and tax amount per tax bracket (5%, 10%, 20%, other), and revenue by product. Line amounts are treated as tax-inclusive. `from`/`to` are optional dates (YYYY-MM-DD); `to` is inclusive.
+// @Tags         sales
+// @Produce      json
+// @Param        granularity  query     string  false  "daily, weekly, or monthly"  default(daily)
+// @Param        from         query     string  false  "Start date (YYYY-MM-DD), inclusive"
+// @Param        to           query     string  false  "End date (YYYY-MM-DD), inclusive"
+// @Success      200  {object}  KPIReport
+// @Failure      400  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Router       /sales/kpi [get]
+func (h *Handler) GetSalesKPI(c *gin.Context) {
+	granularity := Granularity(strings.ToLower(c.DefaultQuery("granularity", string(GranularityDaily))))
+
+	var from, to *time.Time
+	if v := c.Query("from"); v != "" {
+		t, err := time.Parse(dateOnlyLayout, v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid from date, expected YYYY-MM-DD"})
+			return
+		}
+		from = &t
+	}
+	if v := c.Query("to"); v != "" {
+		t, err := time.Parse(dateOnlyLayout, v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid to date, expected YYYY-MM-DD"})
+			return
+		}
+		t = t.AddDate(0, 0, 1) // to is inclusive of the given day
+		to = &t
+	}
+
+	report, err := h.service.GetSalesKPI(c.Request.Context(), granularity, from, to)
+	if err != nil {
+		if errors.Is(err, ErrInvalidGranularity) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "internal error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
 }
 
 // @Summary      Update a sale

--- a/app/internal/sale/kpi.go
+++ b/app/internal/sale/kpi.go
@@ -1,0 +1,187 @@
+package sale
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+type Granularity string
+
+const (
+	GranularityDaily   Granularity = "daily"
+	GranularityWeekly  Granularity = "weekly"
+	GranularityMonthly Granularity = "monthly"
+)
+
+const otherTaxBracketLabel = "other"
+
+// taxBracketDefs are the tax brackets broken out explicitly in reports; any
+// line with a different rate is grouped under otherTaxBracketLabel so totals
+// still reconcile with TotalRevenue.
+var taxBracketDefs = []struct {
+	Label string
+	Rate  decimal.Decimal
+}{
+	{Label: "5%", Rate: decimal.NewFromFloat(0.05)},
+	{Label: "10%", Rate: decimal.NewFromFloat(0.10)},
+	{Label: "20%", Rate: decimal.NewFromFloat(0.20)},
+}
+
+func taxBracketLabel(rate decimal.Decimal) string {
+	for _, b := range taxBracketDefs {
+		if rate.Equal(b.Rate) {
+			return b.Label
+		}
+	}
+	return otherTaxBracketLabel
+}
+
+// taxAmountFromInclusive extracts the tax portion of a tax-inclusive amount:
+// tax = amount * rate / (1 + rate).
+func taxAmountFromInclusive(amount, rate decimal.Decimal) decimal.Decimal {
+	if rate.IsZero() {
+		return decimal.Zero
+	}
+	return amount.Mul(rate).Div(decimal.NewFromInt(1).Add(rate))
+}
+
+type TaxBracketBreakdown struct {
+	Rate      decimal.Decimal `json:"rate"`
+	Revenue   decimal.Decimal `json:"revenue"`
+	TaxAmount decimal.Decimal `json:"tax_amount"`
+}
+
+type ProductBreakdown struct {
+	ItemID   uuid.UUID       `json:"item_id"`
+	Name     string          `json:"name"`
+	Quantity int             `json:"quantity"`
+	Revenue  decimal.Decimal `json:"revenue"`
+}
+
+type KPIPeriod struct {
+	Period              string                          `json:"period"`
+	PeriodStart         time.Time                       `json:"period_start"`
+	TotalRevenue        decimal.Decimal                 `json:"total_revenue"`
+	SalesCount          int                             `json:"sales_count"`
+	RevenueByTaxBracket map[string]*TaxBracketBreakdown `json:"revenue_by_tax_bracket"`
+	RevenueByProduct    []*ProductBreakdown             `json:"revenue_by_product"`
+}
+
+type KPIReport struct {
+	Granularity Granularity  `json:"granularity"`
+	Periods     []*KPIPeriod `json:"periods"`
+}
+
+// bucketFor returns the period key and period start for ts at the given granularity.
+// Weekly buckets are ISO weeks (Monday start), labeled "<iso-year>-W<iso-week>".
+func bucketFor(ts time.Time, g Granularity) (key string, start time.Time) {
+	loc := ts.Location()
+	switch g {
+	case GranularityMonthly:
+		start = time.Date(ts.Year(), ts.Month(), 1, 0, 0, 0, 0, loc)
+		key = start.Format("2006-01")
+	case GranularityWeekly:
+		dayStart := time.Date(ts.Year(), ts.Month(), ts.Day(), 0, 0, 0, 0, loc)
+		offsetFromMonday := (int(ts.Weekday()) + 6) % 7
+		start = dayStart.AddDate(0, 0, -offsetFromMonday)
+		isoYear, isoWeek := start.ISOWeek()
+		key = fmt.Sprintf("%d-W%02d", isoYear, isoWeek)
+	default:
+		start = time.Date(ts.Year(), ts.Month(), ts.Day(), 0, 0, 0, 0, loc)
+		key = start.Format("2006-01-02")
+	}
+	return key, start
+}
+
+// aggregateSalesKPI groups sales into periods and computes, per period, total
+// revenue, revenue/tax-amount per tax bracket, and revenue per product. Line
+// amounts are treated as tax-inclusive (UnitPrice already includes tax).
+func aggregateSalesKPI(sales []*Sale, granularity Granularity) *KPIReport {
+	periods := make([]*KPIPeriod, 0)
+	periodIndex := make(map[string]*KPIPeriod)
+	productIndex := make(map[string]map[uuid.UUID]*ProductBreakdown)
+
+	for _, sl := range sales {
+		key, start := bucketFor(sl.TimeStamp, granularity)
+		period, ok := periodIndex[key]
+		if !ok {
+			period = &KPIPeriod{
+				Period:              key,
+				PeriodStart:         start,
+				TotalRevenue:        decimal.Zero,
+				RevenueByTaxBracket: map[string]*TaxBracketBreakdown{},
+				RevenueByProduct:    []*ProductBreakdown{},
+			}
+			periodIndex[key] = period
+			productIndex[key] = map[uuid.UUID]*ProductBreakdown{}
+			periods = append(periods, period)
+		}
+		period.SalesCount++
+
+		for _, line := range sl.Lines {
+			qty := decimal.NewFromInt(int64(line.Quantity))
+			lineRevenue := line.UnitPrice.Mul(qty)
+			period.TotalRevenue = period.TotalRevenue.Add(lineRevenue)
+
+			label := taxBracketLabel(line.TaxRate)
+			bracket, ok := period.RevenueByTaxBracket[label]
+			if !ok {
+				rate := line.TaxRate
+				if label == otherTaxBracketLabel {
+					rate = decimal.Zero
+				}
+				bracket = &TaxBracketBreakdown{Rate: rate, Revenue: decimal.Zero, TaxAmount: decimal.Zero}
+				period.RevenueByTaxBracket[label] = bracket
+			}
+			bracket.Revenue = bracket.Revenue.Add(lineRevenue)
+			bracket.TaxAmount = bracket.TaxAmount.Add(taxAmountFromInclusive(lineRevenue, line.TaxRate))
+
+			prod, ok := productIndex[key][line.ItemID]
+			if !ok {
+				prod = &ProductBreakdown{ItemID: line.ItemID, Name: line.Name, Revenue: decimal.Zero}
+				productIndex[key][line.ItemID] = prod
+				period.RevenueByProduct = append(period.RevenueByProduct, prod)
+			}
+			prod.Quantity += line.Quantity
+			prod.Revenue = prod.Revenue.Add(lineRevenue)
+		}
+	}
+
+	for _, p := range periods {
+		p.TotalRevenue = p.TotalRevenue.Round(2)
+		for _, b := range p.RevenueByTaxBracket {
+			b.Revenue = b.Revenue.Round(2)
+			b.TaxAmount = b.TaxAmount.Round(2)
+		}
+		for _, pr := range p.RevenueByProduct {
+			pr.Revenue = pr.Revenue.Round(2)
+		}
+		sort.Slice(p.RevenueByProduct, func(i, j int) bool {
+			return p.RevenueByProduct[i].Revenue.GreaterThan(p.RevenueByProduct[j].Revenue)
+		})
+	}
+
+	return &KPIReport{Granularity: granularity, Periods: periods}
+}
+
+func isValidGranularity(g Granularity) bool {
+	return g == GranularityDaily || g == GranularityWeekly || g == GranularityMonthly
+}
+
+func (s *Service) GetSalesKPI(ctx context.Context, granularity Granularity, from, to *time.Time) (*KPIReport, error) {
+	if !isValidGranularity(granularity) {
+		return nil, ErrInvalidGranularity
+	}
+
+	sales, err := s.repo.FindInRange(ctx, from, to)
+	if err != nil {
+		return nil, err
+	}
+
+	return aggregateSalesKPI(sales, granularity), nil
+}

--- a/app/internal/sale/repository.go
+++ b/app/internal/sale/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	"tili/app/pkg/db"
 
@@ -50,6 +51,26 @@ func (r *Repository) FindAll(ctx context.Context) ([]*Sale, error) {
 		Where("s.is_deleted = ?", false).
 		OrderExpr("s.time_stamp DESC").
 		Scan(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return sales, nil
+}
+
+// FindInRange returns non-deleted sales with time_stamp in [from, to), ordered
+// chronologically. A nil bound leaves that side of the range open.
+func (r *Repository) FindInRange(ctx context.Context, from, to *time.Time) ([]*Sale, error) {
+	var sales []*Sale
+	q := r.db.NewSelect().
+		Model(&sales).
+		Where("s.is_deleted = ?", false)
+	if from != nil {
+		q = q.Where("s.time_stamp >= ?", *from)
+	}
+	if to != nil {
+		q = q.Where("s.time_stamp < ?", *to)
+	}
+	err := q.OrderExpr("s.time_stamp ASC").Scan(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request introduces a new sales KPI reporting endpoint and the supporting logic and data structures for generating revenue reports bucketed by day, week, or month. It also adds a repository method for querying sales within a date range and updates the routing and handler logic to expose the new KPI report.

**Sales KPI Reporting:**

* Added a new `/sales/kpi` GET endpoint to the sales API, which returns revenue KPIs bucketed by day, week, or month. The report includes total revenue, revenue and tax amount per tax bracket (5%, 10%, 20%, other), and revenue by product. Query parameters allow filtering by date range and choosing granularity. [[1]](diffhunk://#diff-b47031141b1fafa82ed974569b7b9b4c1a8ba45cec3a2fc7f275c99e74be6538R33) [[2]](diffhunk://#diff-b47031141b1fafa82ed974569b7b9b4c1a8ba45cec3a2fc7f275c99e74be6538R126-R171)

**KPI Calculation Logic and Data Structures:**

* Implemented the `KPIReport` data structure, period bucketing, and aggregation logic in the new `app/internal/sale/kpi.go` file. This includes handling tax brackets, tax-inclusive calculations, and product breakdowns, as well as rounding and sorting results.

**Repository Enhancements:**

* Added the `FindInRange` method to the sales repository, enabling efficient querying of sales within a specified date range for KPI calculations.

**Supporting Changes:**

* Updated imports and constants in `handler.go` to support date parsing and string manipulation for the new endpoint. [[1]](diffhunk://#diff-b47031141b1fafa82ed974569b7b9b4c1a8ba45cec3a2fc7f275c99e74be6538R6-R7) [[2]](diffhunk://#diff-b47031141b1fafa82ed974569b7b9b4c1a8ba45cec3a2fc7f275c99e74be6538R16-R17)
* Added necessary imports in `repository.go` for date handling.